### PR TITLE
Fix rm_msgs generation problem on clean make

### DIFF
--- a/rm_common/CMakeLists.txt
+++ b/rm_common/CMakeLists.txt
@@ -57,6 +57,9 @@ target_link_libraries(rm_common ${catkin_LIBRARIES})
 #target_link_libraries(test_traj rm_common ${catkin_LIBRARIES})
 target_link_libraries(test_kalman rm_common ${catkin_LIBRARIES})
 
+# Fix rm_msgs generation problem
+# See https://answers.ros.org/question/73048
+add_dependencies(rm_common rm_msgs_generate_messages_cpp)
 
 #############
 ## Install ##


### PR DESCRIPTION
When you use catkin_make with make -jxx, rm_msgs may be compiled later than
targets which need it. It will throw an error on a clean workspace and works
perfectly later on.

- See https://answers.ros.org/question/73048