### PR TITLE
ci: using Netlify for continuous docs integration

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: mkdir build
       - uses: mattnotmitt/doxygen-action@v1
-      
+
       - name: Get Branch Name
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
@@ -23,13 +23,13 @@ jobs:
         run: |
           echo "DEPLOY_NAME=${{ env.BRANCH_NAME }}" >> $GITHUB_ENV
           echo "PRODUCTION=${{ env.BRANCH_NAME == 'master' }}" >> $GITHUB_ENV
-          
+
       - name: Get Deploy Name
         if: github.event_name != 'push'
         run: |
           echo "DEPLOY_NAME=deploy-preview-${{ github.event.number }}" >> $GITHUB_ENV
           echo "PRODUCTION=false" >> $GITHUB_ENV
-          
+
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:


### PR DESCRIPTION
从 Github Pages 切到 Netlify 可以方便 pr 级别的 preview 和 master 分支文档部署，同时减小 repo 的体积（ build dist 和 repo 分离）
但是 action 的变化在这个 pr 看不到，因为 Github 出于安全性考虑限制了 fork repo 触发的 action 获取 secrets（改到 `pull_request_target` 可以解决），实际更改得在这个 pr 合并之后，下个 pr 和 push 才能看到。