### PR TITLE
Load imu params into gazebo

### DIFF
--- a/rm_gazebo/launch/big_resource.launch
+++ b/rm_gazebo/launch/big_resource.launch
@@ -8,6 +8,7 @@
     <arg name="roller_type" default="simple" doc="simple or realistic"/>
 
     <rosparam file="$(find rm_gazebo)/config/mimic_joint.yaml" command="load"/>
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
 
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)

--- a/rm_gazebo/launch/empty_world.launch
+++ b/rm_gazebo/launch/empty_world.launch
@@ -8,6 +8,7 @@
     <arg name="roller_type" default="simple" doc="simple or realistic"/>
 
     <rosparam file="$(find rm_gazebo)/config/mimic_joint.yaml" command="load"/>
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
 
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)

--- a/rm_gazebo/launch/exchange_station.launch
+++ b/rm_gazebo/launch/exchange_station.launch
@@ -11,6 +11,7 @@
     <arg name="load_arm" default="true"/>
     <arg name="paused" default="false"/>
 
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)
          load_arm:=$(arg load_arm)

--- a/rm_gazebo/launch/rmuc.launch
+++ b/rm_gazebo/launch/rmuc.launch
@@ -11,6 +11,7 @@
     <arg name="load_arm" default="true"/>
     <arg name="paused" default="false"/>
 
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)
          load_arm:=$(arg load_arm)

--- a/rm_gazebo/launch/sentry_world.launch
+++ b/rm_gazebo/launch/sentry_world.launch
@@ -11,6 +11,7 @@
     <arg name="load_arm" default="true"/>
     <arg name="paused" default="false"/>
 
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)
          load_arm:=$(arg load_arm)

--- a/rm_gazebo/launch/small_resource.launch
+++ b/rm_gazebo/launch/small_resource.launch
@@ -11,6 +11,7 @@
     <arg name="load_arm" default="true"/>
     <arg name="paused" default="false"/>
 
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)
          load_arm:=$(arg load_arm)

--- a/rm_gazebo/launch/stone.launch
+++ b/rm_gazebo/launch/stone.launch
@@ -12,6 +12,7 @@
     <arg name="paused" default="false"/>
 
     <rosparam file="$(find rm_gazebo)/config/mimic_joint.yaml" command="load"/>
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
 
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)

--- a/rm_gazebo/launch/warthog_race_world.launch
+++ b/rm_gazebo/launch/warthog_race_world.launch
@@ -11,6 +11,7 @@
     <arg name="load_arm" default="true"/>
     <arg name="paused" default="false"/>
 
+    <rosparam file="$(find rm_gazebo)/config/imus.yaml" command="load" if="$(arg load_gimbal)"/>
     <param name="robot_description" command="$(find xacro)/xacro $(find rm_description)/urdf/$(arg robot_type)/$(arg robot_type).urdf.xacro
          load_chassis:=$(arg load_chassis) load_gimbal:=$(arg load_gimbal) load_shooter:=$(arg load_shooter)
          load_arm:=$(arg load_arm)

--- a/rm_gazebo/src/rm_robot_hw_sim.cpp
+++ b/rm_gazebo/src/rm_robot_hw_sim.cpp
@@ -113,6 +113,13 @@ void RmRobotHWSim::parseImu(XmlRpc::XmlRpcValue& imu_datas, const gazebo::physic
       ROS_ERROR_STREAM("Imu " << it->first << " has no associated linear acceleration covariance.");
       continue;
     }
+    std::string frame_id = imu_datas[it->first]["frame_id"];
+    gazebo::physics::LinkPtr link_ptr = parent_model->GetLink(frame_id);
+    if (link_ptr == nullptr)
+    {
+      ROS_WARN("Imu %s is not specified in urdf.", it->first.c_str());
+      continue;
+    }
     XmlRpc::XmlRpcValue ori_cov = imu_datas[it->first]["orientation_covariance_diagonal"];
     ROS_ASSERT(ori_cov.getType() == XmlRpc::XmlRpcValue::TypeArray);
     ROS_ASSERT(ori_cov.size() == 3);
@@ -129,9 +136,6 @@ void RmRobotHWSim::parseImu(XmlRpc::XmlRpcValue& imu_datas, const gazebo::physic
     for (int i = 0; i < linear_cov.size(); ++i)
       ROS_ASSERT(linear_cov[i].getType() == XmlRpc::XmlRpcValue::TypeDouble);
 
-    std::string frame_id = imu_datas[it->first]["frame_id"];
-    gazebo::physics::LinkPtr link_ptr = parent_model->GetLink(frame_id);
-    ROS_ASSERT(link_ptr != nullptr);
     imu_datas_.push_back((ImuData{
         .link_prt = link_ptr,
         .ori = { 0., 0., 0., 0. },


### PR DESCRIPTION
在rm_gazebo里每个launch文件都添加了，假如加载云台就也加载imu的配置文件，不然加载云台控制器时会报错。同时由于多个机器人共享同一个imus.yaml，为增加通用性，更改了gazebo插件加载imu的策略：假如在imus.yaml里定义了一个imu但是在urdf里找不到对应的link，直接跳过并给出warning。