### PR TITLE
Delete target_velocity in GimbalCmd.msg

### DIFF
--- a/rm_msgs/msg/GimbalCmd.msg
+++ b/rm_msgs/msg/GimbalCmd.msg
@@ -12,4 +12,3 @@ float64 rate_pitch
 # TRACK/DIRECT
 float64 bullet_speed
 geometry_msgs/PointStamped target_pos
-geometry_msgs/Vector3Stamped target_vel


### PR DESCRIPTION
direct 模式不需要 target_velocity，删掉之后编译云台控制器没有报错，可证实确实没用。