### PR TITLE
Add "distance_to_image_center" to detection message type

### DIFF
--- a/rm_msgs/msg/detection/TargetDetection.msg
+++ b/rm_msgs/msg/detection/TargetDetection.msg
@@ -1,3 +1,4 @@
 uint8 id
+float64 distance_to_image_center
 float64 confidence
 geometry_msgs/Pose pose


### PR DESCRIPTION
在detection的消息类型中添加了在图像坐标系中装甲板中心到图像中心的距离这一变量。