### PR TITLE
Remove 0x01 char from changelog

### DIFF
--- a/rm_referee/CHANGELOG.rst
+++ b/rm_referee/CHANGELOG.rst
@@ -79,37 +79,6 @@ Changelog for package rm_referee
 * Ui work success,ore ui is in test.
 * Try reuse power limit state.
 * Change Variable name,color problem in powerlimitstate.
-* Merge branch 'referee1' of github.com:chenhuiYu00/rm_control into referee1
-   Conflicts:
-  	rm_common/include/rm_common/decision/command_sender.h
-  	rm_common/include/rm_common/decision/service_caller.h
-  	rm_msgs/msg/referee/CalibrationStatus.msg
-  	rm_msgs/msg/referee/CapacityData.msg
-  	rm_msgs/msg/referee/DetectionStatus.msg
-  	rm_msgs/msg/referee/EngineerCmd.msg
-  	rm_msgs/msg/referee/GameRobotHp.msg
-  	rm_msgs/msg/referee/GameRobotStatus.msg
-  	rm_msgs/msg/referee/GameStatus.msg
-  	rm_msgs/msg/referee/PowerHeatData.msg
-  	rm_msgs/msg/referee/StateCmd.msg
-  	rm_referee/config/standard3.yaml
-  	rm_referee/include/rm_referee/common/data.h
-  	rm_referee/include/rm_referee/common/referee_base.h
-  	rm_referee/include/rm_referee/engineer_referee.h
-  	rm_referee/include/rm_referee/hero_referee.h
-  	rm_referee/include/rm_referee/referee/referee.h
-  	rm_referee/include/rm_referee/referee/ui.h
-  	rm_referee/include/rm_referee/robot_referee.h
-  	rm_referee/include/rm_referee/standard_referee.h
-  	rm_referee/launch/load.launch
-  	rm_referee/src/common/referee_base.cpp
-  	rm_referee/src/engineer_referee.cpp
-  	rm_referee/src/hero_referee.cpp
-  	rm_referee/src/main.cpp
-  	rm_referee/src/referee/referee.cpp
-  	rm_referee/src/referee/ui.cpp
-  	rm_referee/src/robot_referee.cpp
-  	rm_referee/src/standard_referee.cpp
 * Fixed some problems,not ready.
 * Update config,referee only send ui once.
 * Add ore remain,dart remain ui.


### PR DESCRIPTION
This removes invalid bytes (value 0x01) in the CHANGELOG. I expect this will resolve https://github.com/ros/rosdistro/issues/35709