### PR TITLE
Improve Reversalcommandersender's extensibility.

### DIFF
--- a/rm_common/CMakeLists.txt
+++ b/rm_common/CMakeLists.txt
@@ -44,6 +44,7 @@ catkin_package(
         DEPENDS
         LIBRARIES
         rm_common
+        control_toolbox
 )
 
 include_directories(

--- a/rm_common/CMakeLists.txt
+++ b/rm_common/CMakeLists.txt
@@ -32,6 +32,7 @@ catkin_package(
         include
         ${EIGEN3_INCLUDE_DIR}
         CATKIN_DEPENDS
+        control_toolbox
         tf
         rm_msgs
         geometry_msgs
@@ -44,7 +45,6 @@ catkin_package(
         DEPENDS
         LIBRARIES
         rm_common
-        control_toolbox
 )
 
 include_directories(

--- a/rm_common/CMakeLists.txt
+++ b/rm_common/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED
         rm_msgs
         geometry_msgs
         control_msgs
+        control_toolbox
         controller_manager_msgs
         imu_complementary_filter
         imu_filter_madgwick

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -112,30 +112,30 @@ class MultiDofCommandSender
 public:
   explicit MultiDofCommandSender(ros::NodeHandle& nh)
   {
-    uint32_t queue_size = getParam(nh, "queue_size", 1);
     XmlRpc::XmlRpcValue config{};
-    std::vector<std::string> topic_names{ "topic_joint1", "topic_joint2", "topic_joint3", "topic_joint4" };
+    uint32_t queue_size = getParam(nh, "queue_size", 1);
     std::vector<std::string> topics{ "topic1", "topic2", "topic3", "topic4" };
     std::vector<std::string> config_names{ "roll_config", "pitch_config", "yaw_config",
                                            "x_config",    "y_config",     "z_config" };
     std::vector<std::string> pid_names{ "pid_roll", "pid_pitch", "pid_yaw", "pid_x", "pid_y", "pid_z" };
+    std::vector<std::string> topic_names{ "topic_joint1", "topic_joint2", "topic_joint3", "topic_joint4" };
     configs_ = { roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_ };
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
                nh.getParam("reversal_max_speed", reversal_max_speed_));
-    for (int i = 0; i < topics.size(); ++i)
+    for (size_t i = 0; i < topics.size(); ++i)
     {
       ROS_ASSERT(nh.getParam(topic_names[i], topics[i]));
       pubs_[i] = nh.advertise<std_msgs::Float64>(topics[i], queue_size);
     }
-    for (int i = 0; i < config_names.size(); ++i)
+    for (size_t i = 0; i < config_names.size(); ++i)
     {
       if (nh.getParam(config_names[i], config))
       {
-        for (int j = 0; i < configs_[i].size(); ++j)
+        for (size_t j = 0; i < configs_[i].size(); ++j)
           configs_[i].push_back(xmlRpcGetDouble(config[j]));
       }
     }
-    for (int i = 0; i < pid_names.size(); ++i)
+    for (size_t i = 0; i < pid_names.size(); ++i)
       pids_[i].init(ros::NodeHandle(nh, pid_names[i]), "pid");
   };
   void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
@@ -152,22 +152,22 @@ public:
                    double z_scale)
   {
     std::vector<double> scales = { roll_scale, pitch_scale, yaw_scale, x_scale, y_scale, z_scale };
-    for (int i = 0; i < msgs_.size(); ++i)
+    for (size_t i = 0; i < msgs_.size(); ++i)
     {
-      for (int j = 0; j < configs_.size() / 2; ++j)
+      for (size_t j = 0; j < configs_.size() / 2; ++j)
         msgs_[i].data += reversal_max_speed_ * configs_[j][i] * scales[j];
-      for (int j = configs_.size() / 2; j < configs_.size(); ++j)
+      for (size_t j = configs_.size() / 2; j < configs_.size(); ++j)
         msgs_[i].data += translate_max_speed_ * configs_[j][i] * scales[j];
     }
   }
   void setZero()
   {
-    for (int i = 0; i < msgs_.size(); ++i)
+    for (size_t i = 0; i < msgs_.size(); ++i)
       msgs_[i].data = 0;
   }
   void sendCommand()
   {
-    for (int i = 0; i < pubs_.size(); ++i)
+    for (size_t i = 0; i < pubs_.size(); ++i)
       pubs_[i].publish(msgs_[i]);
   }
 

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -149,14 +149,14 @@ public:
     if (nh.getParam("y", y_config))
     {
       for (int i = 0; i < x_config.size(); ++i)
-          y_config_.push_back(xmlRpcGetDouble(y_config[i]));
+        y_config_.push_back(xmlRpcGetDouble(y_config[i]));
       ros::NodeHandle nh_pid_y = ros::NodeHandle(nh, "pid_y");
       pid_y_.init(ros::NodeHandle(nh_pid_y, "pid"));
     }
     if (nh.getParam("z", z_config))
     {
       for (int i = 0; i < z_config.size(); ++i)
-          z_config_.push_back(xmlRpcGetDouble(z_config[i]));
+        z_config_.push_back(xmlRpcGetDouble(z_config[i]));
       ros::NodeHandle nh_pid_z = ros::NodeHandle(nh, "pid_z");
       pid_z_.init(ros::NodeHandle(nh_pid_z, "pid"));
     }
@@ -168,13 +168,13 @@ public:
   void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
                       double error_z, ros::Duration period)
   {
-      double roll_scale = pid_roll_.computeCommand(error_roll,period);
-      double pitch_scale = pid_pitch_.computeCommand(error_pitch,period);
-      double yaw_scale = pid_yaw_.computeCommand(error_yaw,period);
-      double x_scale = pid_x_.computeCommand(error_x,period);
-      double y_scale = pid_y_.computeCommand(error_y,period);
-      double z_scale = pid_z_.computeCommand(error_roll,period);
-      setGroupVel(roll_scale,pitch_scale,yaw_scale,x_scale,y_scale,z_scale);
+    double roll_scale = pid_roll_.computeCommand(error_roll, period);
+    double pitch_scale = pid_pitch_.computeCommand(error_pitch, period);
+    double yaw_scale = pid_yaw_.computeCommand(error_yaw, period);
+    double x_scale = pid_x_.computeCommand(error_x, period);
+    double y_scale = pid_y_.computeCommand(error_y, period);
+    double z_scale = pid_z_.computeCommand(error_roll, period);
+    setGroupVel(roll_scale, pitch_scale, yaw_scale, x_scale, y_scale, z_scale);
   }
   void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
                    double z_scale)

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -114,9 +114,8 @@ public:
     XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
                nh.getParam("reversal_max_speed", reversal_max_speed_));
-    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1_) &&
-                 nh.getParam("topic_joint2", topic_joint2_) && nh.getParam("topic_joint3", topic_joint3_) &&
-                 nh.getParam("topic_joint4", topic_joint4_));
+    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1_) && nh.getParam("topic_joint2", topic_joint2_) &&
+               nh.getParam("topic_joint3", topic_joint3_) && nh.getParam("topic_joint4", topic_joint4_));
     if (nh.getParam("roll", roll_config))
     {
       for (int i = 0; i < roll_config.size(); ++i)

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -172,14 +172,15 @@ public:
   }
 
 protected:
-  std::vector<control_toolbox::Pid> pids_ = std::vector<control_toolbox::Pid>(6);
-  control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
+  double translate_max_speed_{},reversal_max_speed_{};
   std::vector<std::vector<double>> configs_{ 6 };
+  std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
+
   std::vector<ros::Publisher> pubs_{ 4 };
   std::vector<std_msgs::Float64> msgs_{ 4 };
-  std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
-  double translate_max_speed_;
-  double reversal_max_speed_;
+
+  std::vector<control_toolbox::Pid> pids_ = std::vector<control_toolbox::Pid>(6);
+  control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
 };
 
 template <class MsgType>

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -142,20 +142,20 @@ public:
     translation_scale = pid_translation_.computeCommand(error_translation, period);
     setGroupVel(roll_scale, pitch_scale, translation_scale);
   }
-  void setGroupVel(double roll_scales, double pitch_scales, double translation_scales)
+  void setGroupVel(double roll_scale, double pitch_scale, double translation_scale)
   {
     double input{};
-    if (roll_scales && pitch_scales)
+    if (roll_scale || pitch_scale)
     {
-      input = abs(roll_scales) > abs(pitch_scales) ? roll_scales : pitch_scales;
-      if (abs(roll_scales) > abs(pitch_scales))
+      input = abs(roll_scale) > abs(pitch_scale) ? roll_scale : pitch_scale;
+      if (abs(roll_scale) > abs(pitch_scale))
       {
         rev_p_f_.data = reversal_max_speed_ * roll_config_[0] * abs(input);
         rev_p_b_.data = reversal_max_speed_ * roll_config_[1] * abs(input);
         rev_r_l_.data = reversal_max_speed_ * roll_config_[2] * input;
         rev_r_r_.data = reversal_max_speed_ * roll_config_[3] * input;
       }
-      else if (abs(roll_scales) < abs(pitch_scales))
+      else if (abs(roll_scale) < abs(pitch_scale))
       {
         rev_p_f_.data = reversal_max_speed_ * pitch_config_[0] * input;
         rev_p_b_.data = reversal_max_speed_ * pitch_config_[1] * input;
@@ -163,9 +163,9 @@ public:
         rev_r_r_.data = reversal_max_speed_ * pitch_config_[3] * abs(input);
       }
     }
-    if (translation_scales)
+    if (translation_scale)
     {
-      input = translation_scales;
+      input = translation_scale;
       tra_p_f_.data = translate_max_speed_ * translate_config_[0] * input;
       tra_p_b_.data = translate_max_speed_ * translate_config_[1] * input;
       tra_r_l_.data = translate_max_speed_ * translate_config_[2] * input;
@@ -176,8 +176,17 @@ public:
     msg_r_l_.data = rev_r_l_.data + tra_r_l_.data;
     msg_r_r_.data = rev_r_r_.data + tra_r_r_.data;
   }
+  void setZero()
+  {
+      msg_p_f_.data = 0;
+      msg_p_b_.data = 0;
+      msg_r_l_.data = 0;
+      msg_r_r_.data = 0;
+  }
   void sendCommand()
   {
+    if(msg_p_b_.data+msg_p_f_.data+msg_r_l_.data+msg_r_r_.data<=0.1)
+        setZero();
     pub_p_f_.publish(msg_p_f_);
     pub_p_b_.publish(msg_p_b_);
     pub_r_l_.publish(msg_r_l_);

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -142,7 +142,7 @@ public:
       if (nh.getParam(pid_names[i], config))
         pids_[i].init(ros::NodeHandle(nh, pid_names[i]), "pid");
       else
-        pids_[i].init(ros::NodeHandle(nh, "pid_zero"), "pid");
+        pids_[i].initPid(0.0, 0.0, 0.0, 0.0, 0.0);
     }
   };
   void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -116,13 +116,14 @@ public:
     ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
     ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "pid_translation");
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_vel_) && nh.getParam("reversal_max_speed", reversal_vel_));
-    ROS_ASSERT(nh.getParam("translate", translation_config)&&nh.getParam("roll", roll_config)&& nh.getParam("pitch", pitch_config));
+    ROS_ASSERT(nh.getParam("translate", translation_config) && nh.getParam("roll", roll_config) &&
+               nh.getParam("pitch", pitch_config));
     for (int i = 0; i < translation_config.size(); i++)
-      {
-        translate_.push_back(xmlRpcGetDouble(translation_config[i]));
-        roll_.push_back(xmlRpcGetDouble(roll_config[i]));
-        pitch_.push_back(xmlRpcGetDouble(pitch_config[i]));
-      }
+    {
+      translate_.push_back(xmlRpcGetDouble(translation_config[i]));
+      roll_.push_back(xmlRpcGetDouble(roll_config[i]));
+      pitch_.push_back(xmlRpcGetDouble(pitch_config[i]));
+    }
     pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
     pid_translation_.init(ros::NodeHandle(nh_pid_translation, "pid"));

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -125,6 +125,41 @@ public:
       ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
       pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     }
+    if (nh.getParam("pitch", pitch_config))
+    {
+      for (int i = 0; i < pitch_config.size(); ++i)
+        pitch_config_.push_back(xmlRpcGetDouble(pitch_config[i]));
+      ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
+      pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
+    }
+    if (nh.getParam("yaw", yaw_config))
+    {
+      for (int i = 0; i < yaw_config.size(); ++i)
+        yaw_config_.push_back(xmlRpcGetDouble(yaw_config[i]));
+      ros::NodeHandle nh_pid_yaw = ros::NodeHandle(nh, "pid_yaw");
+      pid_yaw_.init(ros::NodeHandle(nh_pid_yaw, "pid"));
+    }
+    if (nh.getParam("x", x_config))
+    {
+      for (int i = 0; i < x_config.size(); ++i)
+        x_config_.push_back(xmlRpcGetDouble(x_config[i]));
+      ros::NodeHandle nh_pid_x = ros::NodeHandle(nh, "pid_x");
+      pid_x_.init(ros::NodeHandle(nh_pid_x, "pid"));
+    }
+    if (nh.getParam("y", y_config))
+    {
+      for (int i = 0; i < x_config.size(); ++i)
+          y_config_.push_back(xmlRpcGetDouble(y_config[i]));
+      ros::NodeHandle nh_pid_y = ros::NodeHandle(nh, "pid_y");
+      pid_y_.init(ros::NodeHandle(nh_pid_y, "pid"));
+    }
+    if (nh.getParam("z", z_config))
+    {
+      for (int i = 0; i < z_config.size(); ++i)
+          z_config_.push_back(xmlRpcGetDouble(z_config[i]));
+      ros::NodeHandle nh_pid_z = ros::NodeHandle(nh, "pid_z");
+      pid_z_.init(ros::NodeHandle(nh_pid_z, "pid"));
+    }
     pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1, queue_size);
     pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2, queue_size);
     pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3, queue_size);
@@ -133,6 +168,13 @@ public:
   void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
                       double error_z, ros::Duration period)
   {
+      double roll_scale = pid_roll_.computeCommand(error_roll,period);
+      double pitch_scale = pid_pitch_.computeCommand(error_pitch,period);
+      double yaw_scale = pid_yaw_.computeCommand(error_yaw,period);
+      double x_scale = pid_x_.computeCommand(error_x,period);
+      double y_scale = pid_y_.computeCommand(error_y,period);
+      double z_scale = pid_z_.computeCommand(error_roll,period);
+      setGroupVel(roll_scale,pitch_scale,yaw_scale,x_scale,y_scale,z_scale);
   }
   void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
                    double z_scale)

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -172,7 +172,7 @@ public:
   }
 
 protected:
-  double translate_max_speed_{},reversal_max_speed_{};
+  double translate_max_speed_{}, reversal_max_speed_{};
   std::vector<std::vector<double>> configs_{ 6 };
   std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
 

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -109,104 +109,114 @@ protected:
 class ReversalCommandSender
 {
 public:
-    explicit ReversalCommandSender(ros::NodeHandle& nh)
+  explicit ReversalCommandSender(ros::NodeHandle& nh)
+  {
+    XmlRpc::XmlRpcValue motor_config;
+    ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "roll");
+    ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pitch");
+    ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "translation");
+    if (!nh.getParam("translate", motor_config))
+      ROS_ERROR("Translate motor group configuration set no defined (namespace: %s)", nh.getNamespace().c_str());
+    else
     {
-        XmlRpc::XmlRpcValue motor_config;
-        ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "roll");
-        ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pitch");
-        ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "translation");
-        if (!nh.getParam("translate", motor_config))
-            ROS_ERROR("Translate motor group configuration set no defined (namespace: %s)", nh.getNamespace().c_str());
-        else
-        {
-            for (int i = 0; i < motor_config.size(); i++)
-            {
-                translate_.push_back(xmlRpcGetDouble(motor_config[i]));
-            }
-        }
-        if (!nh.getParam("rev_roll", motor_config))
-            ROS_ERROR("Reversal roll motor group configuration set no defined (namespace: %s)", nh.getNamespace().c_str());
-        else
-        {
-            for (int i = 0; i < motor_config.size(); i++)
-            {
-                rev_roll_.push_back(xmlRpcGetDouble(motor_config[i]));
-            }
-        }
-        if (!nh.getParam("rev_pitch", motor_config))
-            ROS_ERROR("Reversal pitch motor group configuration set no defined (namespace: %s)", nh.getNamespace().c_str());
-        else
-        {
-            for (int i = 0; i < motor_config.size(); i++)
-            {
-                rev_pitch_.push_back(xmlRpcGetDouble(motor_config[i]));
-            }
-        }
-        pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
-        pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
-        pid_translation_.init(ros::NodeHandle(nh_pid_translation, "pid"));
-        queue_size_ = getParam(nh, "queue_size", 1);
-        pub_p_f_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_front_controller/command", queue_size_);
-        pub_p_b_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_behind_controller/command", queue_size_);
-        pub_r_l_ = nh.advertise<std_msgs::Float64>("/controllers/roll_left_controller/command", queue_size_);
-        pub_r_r_ = nh.advertise<std_msgs::Float64>("/controllers/roll_right_controller/command", queue_size_);
-        ROS_ASSERT(nh.getParam("translate_max_speed", translate_vel_) && nh.getParam("reversal_max_speed", reversal_vel_));
-    };
-
-    void VisionReversal(double error_roll, double error_pitch, double error_translation, ros::Duration period){
-        double roll_scales{},pitch_scales{},translation_scales{};
-        roll_scales = pid_roll_.computeCommand(error_roll, period)/M_PI;
-        pitch_scales = pid_pitch_.computeCommand(error_pitch, period)/(2 * M_PI);
-        translation_scales = pid_translation_.computeCommand(error_translation, period);
-        setGroupVel(roll_scales,pitch_scales,translation_scales);
+      for (int i = 0; i < motor_config.size(); i++)
+      {
+        translate_.push_back(xmlRpcGetDouble(motor_config[i]));
+      }
     }
-
-    void setGroupVel(double roll_scales, double pitch_scales, double translation_scales) {
-        double input{};
-        if (roll_scales + pitch_scales != 0) {
-            input = abs(roll_scales) > abs(pitch_scales) ? roll_scales : pitch_scales;
-            if (abs(roll_scales) > abs(pitch_scales)) {
-                msg_p_f_.data = reversal_vel_ * rev_roll_[0] * abs(input);
-                msg_p_b_.data = reversal_vel_ * rev_roll_[1] * abs(input);
-                msg_r_l_.data = reversal_vel_ * rev_roll_[2] * input;
-                msg_r_r_.data = reversal_vel_ * rev_roll_[3] * input;
-            } else if (abs(roll_scales) < abs(pitch_scales)) {
-                msg_p_f_.data = reversal_vel_ * rev_pitch_[0] * input;
-                msg_p_b_.data = reversal_vel_ * rev_pitch_[1] * input;
-                msg_r_l_.data = reversal_vel_ * rev_pitch_[2] * abs(input);
-                msg_r_r_.data = reversal_vel_ * rev_pitch_[3] * abs(input);
-            }
-        } else if (translation_scales != 0) {
-            input = translation_scales;
-            msg_p_f_.data = translate_vel_ * translate_[0] * input;
-            msg_p_b_.data = translate_vel_ * translate_[1] * input;
-            msg_r_l_.data = translate_vel_ * translate_[2] * input;
-            msg_r_r_.data = translate_vel_ * translate_[3] * input;
-        }else if (roll_scales + pitch_scales + translation_scales == 0)
-            setZero();
-    }
-
-    void sendCommand()
+    if (!nh.getParam("rev_roll", motor_config))
+      ROS_ERROR("Reversal roll motor group configuration set no defined (namespace: %s)", nh.getNamespace().c_str());
+    else
     {
-        pub_p_f_.publish(msg_p_f_) ;
-        pub_p_b_.publish(msg_p_b_) ;
-        pub_r_l_.publish(msg_r_l_) ;
-        pub_r_r_.publish(msg_r_r_) ;
+      for (int i = 0; i < motor_config.size(); i++)
+      {
+        rev_roll_.push_back(xmlRpcGetDouble(motor_config[i]));
+      }
     }
-    void setZero()
+    if (!nh.getParam("rev_pitch", motor_config))
+      ROS_ERROR("Reversal pitch motor group configuration set no defined (namespace: %s)", nh.getNamespace().c_str());
+    else
     {
-        msg_p_f_.data = 0;
-        msg_p_b_.data = 0;
-        msg_r_l_.data = 0;
-        msg_r_r_.data = 0;
+      for (int i = 0; i < motor_config.size(); i++)
+      {
+        rev_pitch_.push_back(xmlRpcGetDouble(motor_config[i]));
+      }
     }
+    pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
+    pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
+    pid_translation_.init(ros::NodeHandle(nh_pid_translation, "pid"));
+    queue_size_ = getParam(nh, "queue_size", 1);
+    pub_p_f_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_front_controller/command", queue_size_);
+    pub_p_b_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_behind_controller/command", queue_size_);
+    pub_r_l_ = nh.advertise<std_msgs::Float64>("/controllers/roll_left_controller/command", queue_size_);
+    pub_r_r_ = nh.advertise<std_msgs::Float64>("/controllers/roll_right_controller/command", queue_size_);
+    ROS_ASSERT(nh.getParam("translate_max_speed", translate_vel_) && nh.getParam("reversal_max_speed", reversal_vel_));
+  };
+
+  void VisionReversal(double error_roll, double error_pitch, double error_translation, ros::Duration period)
+  {
+    double roll_scales{}, pitch_scales{}, translation_scales{};
+    roll_scales = pid_roll_.computeCommand(error_roll, period) / M_PI;
+    pitch_scales = pid_pitch_.computeCommand(error_pitch, period) / (2 * M_PI);
+    translation_scales = pid_translation_.computeCommand(error_translation, period);
+    setGroupVel(roll_scales, pitch_scales, translation_scales);
+  }
+
+  void setGroupVel(double roll_scales, double pitch_scales, double translation_scales)
+  {
+    double input{};
+    if (roll_scales + pitch_scales != 0)
+    {
+      input = abs(roll_scales) > abs(pitch_scales) ? roll_scales : pitch_scales;
+      if (abs(roll_scales) > abs(pitch_scales))
+      {
+        msg_p_f_.data = reversal_vel_ * rev_roll_[0] * abs(input);
+        msg_p_b_.data = reversal_vel_ * rev_roll_[1] * abs(input);
+        msg_r_l_.data = reversal_vel_ * rev_roll_[2] * input;
+        msg_r_r_.data = reversal_vel_ * rev_roll_[3] * input;
+      }
+      else if (abs(roll_scales) < abs(pitch_scales))
+      {
+        msg_p_f_.data = reversal_vel_ * rev_pitch_[0] * input;
+        msg_p_b_.data = reversal_vel_ * rev_pitch_[1] * input;
+        msg_r_l_.data = reversal_vel_ * rev_pitch_[2] * abs(input);
+        msg_r_r_.data = reversal_vel_ * rev_pitch_[3] * abs(input);
+      }
+    }
+    else if (translation_scales != 0)
+    {
+      input = translation_scales;
+      msg_p_f_.data = translate_vel_ * translate_[0] * input;
+      msg_p_b_.data = translate_vel_ * translate_[1] * input;
+      msg_r_l_.data = translate_vel_ * translate_[2] * input;
+      msg_r_r_.data = translate_vel_ * translate_[3] * input;
+    }
+    else if (roll_scales + pitch_scales + translation_scales == 0)
+      setZero();
+  }
+
+  void sendCommand()
+  {
+    pub_p_f_.publish(msg_p_f_);
+    pub_p_b_.publish(msg_p_b_);
+    pub_r_l_.publish(msg_r_l_);
+    pub_r_r_.publish(msg_r_r_);
+  }
+  void setZero()
+  {
+    msg_p_f_.data = 0;
+    msg_p_b_.data = 0;
+    msg_r_l_.data = 0;
+    msg_r_r_.data = 0;
+  }
+
 protected:
-    uint32_t queue_size_;
-    double reversal_vel_,translate_vel_;
-    ros::Publisher pub_r_l_,pub_r_r_,pub_p_f_,pub_p_b_;
-    std::vector<double> translate_,rev_roll_,rev_pitch_;
-    std_msgs::Float64 msg_p_f_,msg_p_b_,msg_r_l_,msg_r_r_;
-    control_toolbox::Pid pid_roll_,pid_pitch_,pid_translation_;
+  uint32_t queue_size_;
+  double reversal_vel_, translate_vel_;
+  ros::Publisher pub_r_l_, pub_r_r_, pub_p_f_, pub_p_b_;
+  std::vector<double> translate_, rev_roll_, rev_pitch_;
+  std_msgs::Float64 msg_p_f_, msg_p_b_, msg_r_l_, msg_r_r_;
+  control_toolbox::Pid pid_roll_, pid_pitch_, pid_translation_;
 };
 template <class MsgType>
 class TimeStampCommandSenderBase : public CommandSenderBase<MsgType>

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -193,8 +193,8 @@ public:
     }
     else if (roll_scales + pitch_scales + translation_scales == 0)
     {
-      msg_p_f_.data = translate_vel_ * translate_[0] * -0.1;
-      msg_p_b_.data = translate_vel_ * translate_[1] * -0.1;
+      msg_p_f_.data = translate_vel_ * translate_[0] * 0.;
+      msg_p_b_.data = translate_vel_ * translate_[1] * 0.;
     }
   }
 

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -116,10 +116,10 @@ public:
                nh.getParam("reversal_max_speed", reversal_max_speed_));
     if (nh.getParam("roll", roll_config))
     {
-        for (int i = 0; i < roll_config.size(); ++i)
-          roll_config_.push_back(xmlRpcGetDouble(roll_config[i]));
-        ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
-        pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
+      for (int i = 0; i < roll_config.size(); ++i)
+        roll_config_.push_back(xmlRpcGetDouble(roll_config[i]));
+      ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
+      pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     }
     queue_size_ = getParam(nh, "queue_size", 1);
     pub_motor1_ = nh.advertise<std_msgs::Float64>("/controllers/motor1_controller/command", queue_size_);
@@ -127,15 +127,25 @@ public:
     pub_motor3_ = nh.advertise<std_msgs::Float64>("/controllers/motor3_controller/command", queue_size_);
     pub_motor4_ = nh.advertise<std_msgs::Float64>("/controllers/motor4_controller/command", queue_size_);
   };
-  void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y, double error_z, ros::Duration period)
+  void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
+                      double error_z, ros::Duration period)
   {
   }
-  void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale, double z_scale)
+  void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
+                   double z_scale)
   {
-    msg_motor1_.data = reversal_max_speed_ * (roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) + (yaw_config_[0] * yaw_scale) + translate_max_speed_ * (x_config_[0] * x_scale) + (y_config_[0] * y_scale) + (z_config_[0] * z_scale);
-    msg_motor2_.data = reversal_max_speed_ * (roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) + (yaw_config_[1] * yaw_scale) + translate_max_speed_ * (x_config_[1] * x_scale) + (y_config_[1] * y_scale) + (z_config_[1] * z_scale);
-    msg_motor3_.data = reversal_max_speed_ * (roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) + (yaw_config_[2] * yaw_scale) + translate_max_speed_ * (x_config_[2] * x_scale) + (y_config_[2] * y_scale) + (z_config_[2] * z_scale);
-    msg_motor4_.data = reversal_max_speed_ * (roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) + (yaw_config_[3] * yaw_scale) + translate_max_speed_ * (x_config_[3] * x_scale) + (y_config_[3] * y_scale) + (z_config_[3] * z_scale);
+    msg_motor1_.data = reversal_max_speed_ * (roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) +
+                       (yaw_config_[0] * yaw_scale) + translate_max_speed_ * (x_config_[0] * x_scale) +
+                       (y_config_[0] * y_scale) + (z_config_[0] * z_scale);
+    msg_motor2_.data = reversal_max_speed_ * (roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) +
+                       (yaw_config_[1] * yaw_scale) + translate_max_speed_ * (x_config_[1] * x_scale) +
+                       (y_config_[1] * y_scale) + (z_config_[1] * z_scale);
+    msg_motor3_.data = reversal_max_speed_ * (roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) +
+                       (yaw_config_[2] * yaw_scale) + translate_max_speed_ * (x_config_[2] * x_scale) +
+                       (y_config_[2] * y_scale) + (z_config_[2] * z_scale);
+    msg_motor4_.data = reversal_max_speed_ * (roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) +
+                       (yaw_config_[3] * yaw_scale) + translate_max_speed_ * (x_config_[3] * x_scale) +
+                       (y_config_[3] * y_scale) + (z_config_[3] * z_scale);
   }
   void setZero()
   {

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -178,15 +178,15 @@ public:
   }
   void setZero()
   {
-      msg_p_f_.data = 0;
-      msg_p_b_.data = 0;
-      msg_r_l_.data = 0;
-      msg_r_r_.data = 0;
+    msg_p_f_.data = 0;
+    msg_p_b_.data = 0;
+    msg_r_l_.data = 0;
+    msg_r_r_.data = 0;
   }
   void sendCommand()
   {
-    if(msg_p_b_.data+msg_p_f_.data+msg_r_l_.data+msg_r_r_.data<=0.1)
-        setZero();
+    if (msg_p_b_.data + msg_p_f_.data + msg_r_l_.data + msg_r_r_.data <= 0.1)
+      setZero();
     pub_p_f_.publish(msg_p_f_);
     pub_p_b_.publish(msg_p_b_);
     pub_r_l_.publish(msg_r_l_);

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -106,10 +106,10 @@ protected:
   ros::Publisher pub_;
   MsgType msg_;
 };
-class ReversalCommandSender
+class MultiDofCommandSender
 {
 public:
-  explicit ReversalCommandSender(ros::NodeHandle& nh)
+  explicit MultiDofCommandSender(ros::NodeHandle& nh)
   {
     XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
@@ -127,16 +127,11 @@ public:
     pub_motor3_ = nh.advertise<std_msgs::Float64>("/controllers/motor3_controller/command", queue_size_);
     pub_motor4_ = nh.advertise<std_msgs::Float64>("/controllers/motor4_controller/command", queue_size_);
   };
-  void visionReversal(double error_roll, double error_pitch, double error_translation, ros::Duration period)
+  void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y, double error_z, ros::Duration period)
   {
-    double roll_scale{}, pitch_scale{}, translation_scale{};
-    roll_scale = pid_roll_.computeCommand(error_roll, period);
-    pitch_scale = pid_pitch_.computeCommand(error_pitch, period);
   }
   void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale, double z_scale)
   {
-    std_msgs::Float64 rev_motor1{}, rev_motor2{}, rev_motor3{}, rev_motor4{},tra_motor1{}, tra_motor2{}, tra_motor3{}, tra_motor4{};
-    double motor1_scale{}, motor2_scale{}, motor3_scale{}, motor4_scale{};
     msg_motor1_.data = reversal_max_speed_ * (roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) + (yaw_config_[0] * yaw_scale) + translate_max_speed_ * (x_config_[0] * x_scale) + (y_config_[0] * y_scale) + (z_config_[0] * z_scale);
     msg_motor2_.data = reversal_max_speed_ * (roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) + (yaw_config_[1] * yaw_scale) + translate_max_speed_ * (x_config_[1] * x_scale) + (y_config_[1] * y_scale) + (z_config_[1] * z_scale);
     msg_motor3_.data = reversal_max_speed_ * (roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) + (yaw_config_[2] * yaw_scale) + translate_max_speed_ * (x_config_[2] * x_scale) + (y_config_[2] * y_scale) + (z_config_[2] * z_scale);

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -135,12 +135,14 @@ public:
           configs_[i].push_back(xmlRpcGetDouble(config[j]));
       }
       else
+      {
         configs_[i] = { 0., 0., 0., 0. };
+      }
     }
     for (size_t i = 0; i < pid_names.size(); ++i)
     {
       if (nh.getParam(pid_names[i], config))
-        pids_[i].init(ros::NodeHandle(nh, pid_names[i]), "pid");
+        pids_[i].init(ros::NodeHandle(ros::NodeHandle(nh, pid_names[i]), "pid"));
       else
         pids_[i].initPid(0.0, 0.0, 0.0, 0.0, 0.0);
     }

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -109,90 +109,91 @@ protected:
 class ReversalCommandSender
 {
 public:
-  explicit ReversalCommandSender(ros::NodeHandle& nh)
-  {
-    XmlRpc::XmlRpcValue roll_config, pitch_config, translation_config;
-    ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
-    ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
-    ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "pid_translation");
-    ROS_ASSERT(nh.getParam("translate_max_speed", translate_vel_) && nh.getParam("reversal_max_speed", reversal_vel_));
-    ROS_ASSERT(nh.getParam("translate", translation_config) && nh.getParam("roll", roll_config) &&
-               nh.getParam("pitch", pitch_config));
-    for (int i = 0; i < translation_config.size(); i++)
+    explicit ReversalCommandSender(ros::NodeHandle& nh)
     {
-      translate_.push_back(xmlRpcGetDouble(translation_config[i]));
-      roll_.push_back(xmlRpcGetDouble(roll_config[i]));
-      pitch_.push_back(xmlRpcGetDouble(pitch_config[i]));
-    }
-    pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
-    pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
-    pid_translation_.init(ros::NodeHandle(nh_pid_translation, "pid"));
-    queue_size_ = getParam(nh, "queue_size", 1);
-    pub_p_f_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_front_controller/command", queue_size_);
-    pub_p_b_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_behind_controller/command", queue_size_);
-    pub_r_l_ = nh.advertise<std_msgs::Float64>("/controllers/roll_left_controller/command", queue_size_);
-    pub_r_r_ = nh.advertise<std_msgs::Float64>("/controllers/roll_right_controller/command", queue_size_);
-  };
-
-  void visionReversal(double error_roll, double error_pitch, double error_translation, ros::Duration period)
-  {
-    double roll_scales{}, pitch_scales{}, translation_scales{};
-    roll_scales = pid_roll_.computeCommand(error_roll, period);
-    pitch_scales = pid_pitch_.computeCommand(error_pitch, period);
-    translation_scales = pid_translation_.computeCommand(error_translation, period);
-    setGroupVel(roll_scales, pitch_scales, translation_scales);
-  }
-
-  void setGroupVel(double roll_scales, double pitch_scales, double translation_scales)
-  {
-    double input{};
-    if (roll_scales + pitch_scales != 0)
+        XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, translation_config{};
+        ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
+        ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
+        ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "pid_translation");
+        ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
+                   nh.getParam("reversal_max_speed", reversal_max_speed_));
+        ROS_ASSERT(nh.getParam("translate", translation_config) && nh.getParam("roll", roll_config) &&
+                   nh.getParam("pitch", pitch_config));
+        for (int i = 0; i < translation_config.size(); i++)
+        {
+            translate_config_.push_back(xmlRpcGetDouble(translation_config[i]));
+            roll_config_.push_back(xmlRpcGetDouble(roll_config[i]));
+            pitch_config_.push_back(xmlRpcGetDouble(pitch_config[i]));
+        }
+        pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
+        pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
+        pid_translation_.init(ros::NodeHandle(nh_pid_translation, "pid"));
+        queue_size_ = getParam(nh, "queue_size", 1);
+        pub_p_f_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_front_controller/command", queue_size_);
+        pub_p_b_ = nh.advertise<std_msgs::Float64>("/controllers/pitch_behind_controller/command", queue_size_);
+        pub_r_l_ = nh.advertise<std_msgs::Float64>("/controllers/roll_left_controller/command", queue_size_);
+        pub_r_r_ = nh.advertise<std_msgs::Float64>("/controllers/roll_right_controller/command", queue_size_);
+    };
+    void visionReversal(double error_roll, double error_pitch, double error_translation, ros::Duration period)
     {
-      input = abs(roll_scales) > abs(pitch_scales) ? roll_scales : pitch_scales;
-      if (abs(roll_scales) > abs(pitch_scales))
-      {
-        rev_p_f_.data = reversal_vel_ * roll_[0] * abs(input);
-        rev_p_b_.data = reversal_vel_ * roll_[1] * abs(input);
-        rev_r_l_.data = reversal_vel_ * roll_[2] * input;
-        rev_r_r_.data = reversal_vel_ * roll_[3] * input;
-      }
-      else if (abs(roll_scales) < abs(pitch_scales))
-      {
-        rev_p_f_.data = reversal_vel_ * pitch_[0] * input;
-        rev_p_b_.data = reversal_vel_ * pitch_[1] * input;
-        rev_r_l_.data = reversal_vel_ * pitch_[2] * abs(input);
-        rev_r_r_.data = reversal_vel_ * pitch_[3] * abs(input);
-      }
+        double roll_scale{}, pitch_scale{}, translation_scale{};
+        roll_scale = pid_roll_.computeCommand(error_roll, period);
+        pitch_scale = pid_pitch_.computeCommand(error_pitch, period);
+        translation_scale = pid_translation_.computeCommand(error_translation, period);
+        setGroupVel(roll_scale, pitch_scale, translation_scale);
     }
-    if (translation_scales != 0)
+    void setGroupVel(double roll_scales, double pitch_scales, double translation_scales)
     {
-      input = translation_scales;
-      tra_p_f_.data = translate_vel_ * translate_[0] * input;
-      tra_p_b_.data = translate_vel_ * translate_[1] * input;
-      tra_r_l_.data = translate_vel_ * translate_[2] * input;
-      tra_r_r_.data = translate_vel_ * translate_[3] * input;
+        double input{};
+        if (roll_scales && pitch_scales)
+        {
+            input = abs(roll_scales) > abs(pitch_scales) ? roll_scales : pitch_scales;
+            if (abs(roll_scales) > abs(pitch_scales))
+            {
+                rev_p_f_.data = reversal_max_speed_ * roll_config_[0] * abs(input);
+                rev_p_b_.data = reversal_max_speed_ * roll_config_[1] * abs(input);
+                rev_r_l_.data = reversal_max_speed_ * roll_config_[2] * input;
+                rev_r_r_.data = reversal_max_speed_ * roll_config_[3] * input;
+            }
+            else if (abs(roll_scales) < abs(pitch_scales))
+            {
+                rev_p_f_.data = reversal_max_speed_ * pitch_config_[0] * input;
+                rev_p_b_.data = reversal_max_speed_ * pitch_config_[1] * input;
+                rev_r_l_.data = reversal_max_speed_ * pitch_config_[2] * abs(input);
+                rev_r_r_.data = reversal_max_speed_ * pitch_config_[3] * abs(input);
+            }
+        }
+        if (translation_scales)
+        {
+            input = translation_scales;
+            tra_p_f_.data = translate_max_speed_ * translate_config_[0] * input;
+            tra_p_b_.data = translate_max_speed_ * translate_config_[1] * input;
+            tra_r_l_.data = translate_max_speed_ * translate_config_[2] * input;
+            tra_r_r_.data = translate_max_speed_ * translate_config_[3] * input;
+        }
+        msg_p_f_.data = rev_p_f_.data + tra_p_f_.data;
+        msg_p_b_.data = rev_p_b_.data + tra_p_b_.data;
+        msg_r_l_.data = rev_r_l_.data + tra_r_l_.data;
+        msg_r_r_.data = rev_r_r_.data + tra_r_r_.data;
     }
-    msg_p_f_.data = rev_p_f_.data + tra_p_f_.data;
-    msg_p_b_.data = rev_p_b_.data + tra_p_b_.data;
-    msg_r_l_.data = rev_r_l_.data + tra_r_l_.data;
-    msg_r_r_.data = rev_r_r_.data + tra_r_r_.data;
-  }
+    void sendCommand()
+    {
+        pub_p_f_.publish(msg_p_f_);
+        pub_p_b_.publish(msg_p_b_);
+        pub_r_l_.publish(msg_r_l_);
+        pub_r_r_.publish(msg_r_r_);
+    }
 
-  void sendCommand()
-  {
-    pub_p_f_.publish(msg_p_f_);
-    pub_p_b_.publish(msg_p_b_);
-    pub_r_l_.publish(msg_r_l_);
-    pub_r_r_.publish(msg_r_r_);
-  }
 protected:
-  uint32_t queue_size_;
-  double reversal_vel_, translate_vel_;
-  ros::Publisher pub_r_l_, pub_r_r_, pub_p_f_, pub_p_b_;
-  std::vector<double> translate_, roll_, pitch_;
-  std_msgs::Float64 msg_p_f_{}, msg_p_b_{}, msg_r_l_{}, msg_r_r_{},rev_p_f_{},rev_p_b_{},rev_r_l_{},rev_r_r_{},tra_p_f_{},tra_p_b_{},tra_r_l_{},tra_r_r_{};
-  control_toolbox::Pid pid_roll_, pid_pitch_, pid_translation_;
+    uint32_t queue_size_;
+    double reversal_max_speed_, translate_max_speed_;
+    ros::Publisher pub_r_l_, pub_r_r_, pub_p_f_, pub_p_b_;
+    std::vector<double> translate_config_, roll_config_, pitch_config_;
+    std_msgs::Float64 msg_p_f_{}, msg_p_b_{}, msg_r_l_{}, msg_r_r_{}, rev_p_f_{}, rev_p_b_{}, rev_r_l_{}, rev_r_r_{},
+            tra_p_f_{}, tra_p_b_{}, tra_r_l_{}, tra_r_r_{};
+    control_toolbox::Pid pid_roll_, pid_pitch_, pid_translation_;
 };
+
 template <class MsgType>
 class TimeStampCommandSenderBase : public CommandSenderBase<MsgType>
 {

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -111,11 +111,13 @@ class MultiDofCommandSender
 public:
   explicit MultiDofCommandSender(ros::NodeHandle& nh)
   {
+    uint32_t queue_size = getParam(nh, "queue_size", 1);;
+    std::string topic_joint1, topic_joint2, topic_joint3, topic_joint4;
     XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
                nh.getParam("reversal_max_speed", reversal_max_speed_));
-    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1_) && nh.getParam("topic_joint2", topic_joint2_) &&
-               nh.getParam("topic_joint3", topic_joint3_) && nh.getParam("topic_joint4", topic_joint4_));
+    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1) && nh.getParam("topic_joint2", topic_joint2) &&
+               nh.getParam("topic_joint3", topic_joint3) && nh.getParam("topic_joint4", topic_joint4));
     if (nh.getParam("roll", roll_config))
     {
       for (int i = 0; i < roll_config.size(); ++i)
@@ -123,11 +125,10 @@ public:
       ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
       pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     }
-    queue_size_ = getParam(nh, "queue_size", 1);
-    pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1_, queue_size_);
-    pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2_, queue_size_);
-    pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3_, queue_size_);
-    pub_joint4_ = nh.advertise<std_msgs::Float64>(topic_joint4_, queue_size_);
+    pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1, queue_size);
+    pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2, queue_size);
+    pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3, queue_size);
+    pub_joint4_ = nh.advertise<std_msgs::Float64>(topic_joint4, queue_size);
   };
   void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
                       double error_z, ros::Duration period)
@@ -165,10 +166,8 @@ public:
   }
 
 protected:
-  uint32_t queue_size_;
   double reversal_max_speed_, translate_max_speed_;
   ros::Publisher pub_joint1_, pub_joint2_, pub_joint3_, pub_joint4_;
-  std::string topic_joint1_, topic_joint2_, topic_joint3_, topic_joint4_;
   std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
   std_msgs::Float64 msg_joint1_{}, msg_joint2_{}, msg_joint3_{}, msg_joint4_{};
   control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -111,7 +111,8 @@ class MultiDofCommandSender
 public:
   explicit MultiDofCommandSender(ros::NodeHandle& nh)
   {
-    uint32_t queue_size = getParam(nh, "queue_size", 1);;
+    uint32_t queue_size = getParam(nh, "queue_size", 1);
+    ;
     std::string topic_joint1, topic_joint2, topic_joint3, topic_joint4;
     XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -114,6 +114,9 @@ public:
     XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
                nh.getParam("reversal_max_speed", reversal_max_speed_));
+    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1_) &&
+                 nh.getParam("topic_joint2", topic_joint2_) && nh.getParam("topic_joint3", topic_joint3_) &&
+                 nh.getParam("topic_joint4", topic_joint4_));
     if (nh.getParam("roll", roll_config))
     {
       for (int i = 0; i < roll_config.size(); ++i)
@@ -122,10 +125,10 @@ public:
       pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     }
     queue_size_ = getParam(nh, "queue_size", 1);
-    pub_motor1_ = nh.advertise<std_msgs::Float64>("/controllers/motor1_controller/command", queue_size_);
-    pub_motor2_ = nh.advertise<std_msgs::Float64>("/controllers/motor2_controller/command", queue_size_);
-    pub_motor3_ = nh.advertise<std_msgs::Float64>("/controllers/motor3_controller/command", queue_size_);
-    pub_motor4_ = nh.advertise<std_msgs::Float64>("/controllers/motor4_controller/command", queue_size_);
+    pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1_, queue_size_);
+    pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2_, queue_size_);
+    pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3_, queue_size_);
+    pub_joint4_ = nh.advertise<std_msgs::Float64>(topic_joint4_, queue_size_);
   };
   void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
                       double error_z, ros::Duration period)
@@ -134,40 +137,41 @@ public:
   void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
                    double z_scale)
   {
-    msg_motor1_.data = reversal_max_speed_ * (roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) +
+    msg_joint1_.data = reversal_max_speed_ * (roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) +
                        (yaw_config_[0] * yaw_scale) + translate_max_speed_ * (x_config_[0] * x_scale) +
                        (y_config_[0] * y_scale) + (z_config_[0] * z_scale);
-    msg_motor2_.data = reversal_max_speed_ * (roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) +
+    msg_joint2_.data = reversal_max_speed_ * (roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) +
                        (yaw_config_[1] * yaw_scale) + translate_max_speed_ * (x_config_[1] * x_scale) +
                        (y_config_[1] * y_scale) + (z_config_[1] * z_scale);
-    msg_motor3_.data = reversal_max_speed_ * (roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) +
+    msg_joint3_.data = reversal_max_speed_ * (roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) +
                        (yaw_config_[2] * yaw_scale) + translate_max_speed_ * (x_config_[2] * x_scale) +
                        (y_config_[2] * y_scale) + (z_config_[2] * z_scale);
-    msg_motor4_.data = reversal_max_speed_ * (roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) +
+    msg_joint4_.data = reversal_max_speed_ * (roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) +
                        (yaw_config_[3] * yaw_scale) + translate_max_speed_ * (x_config_[3] * x_scale) +
                        (y_config_[3] * y_scale) + (z_config_[3] * z_scale);
   }
   void setZero()
   {
-    msg_motor1_.data = 0;
-    msg_motor2_.data = 0;
-    msg_motor3_.data = 0;
-    msg_motor4_.data = 0;
+    msg_joint1_.data = 0;
+    msg_joint2_.data = 0;
+    msg_joint3_.data = 0;
+    msg_joint4_.data = 0;
   }
   void sendCommand()
   {
-    pub_motor1_.publish(msg_motor1_);
-    pub_motor2_.publish(msg_motor2_);
-    pub_motor3_.publish(msg_motor3_);
-    pub_motor4_.publish(msg_motor4_);
+    pub_joint1_.publish(msg_joint1_);
+    pub_joint2_.publish(msg_joint2_);
+    pub_joint3_.publish(msg_joint3_);
+    pub_joint4_.publish(msg_joint4_);
   }
 
 protected:
   uint32_t queue_size_;
   double reversal_max_speed_, translate_max_speed_;
-  ros::Publisher pub_motor1_, pub_motor2_, pub_motor3_, pub_motor4_;
+  ros::Publisher pub_joint1_, pub_joint2_, pub_joint3_, pub_joint4_;
+  std::string topic_joint1_, topic_joint2_, topic_joint3_, topic_joint4_;
   std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
-  std_msgs::Float64 msg_motor1_{}, msg_motor2_{}, msg_motor3_{}, msg_motor4_{};
+  std_msgs::Float64 msg_joint1_{}, msg_joint2_{}, msg_joint3_{}, msg_joint4_{};
   control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
 };
 

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -112,16 +112,16 @@ public:
   explicit ReversalCommandSender(ros::NodeHandle& nh)
   {
     XmlRpc::XmlRpcValue roll_config, pitch_config, translation_config;
-    ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "roll");
-    ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pitch");
-    ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "translation");
+    ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
+    ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
+    ros::NodeHandle nh_pid_translation = ros::NodeHandle(nh, "pid_translation");
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_vel_) && nh.getParam("reversal_max_speed", reversal_vel_));
-    ROS_ASSERT(nh.getParam("translate", translation_config)&&nh.getParam("rev_roll", roll_config)&& nh.getParam("rev_pitch", pitch_config));
+    ROS_ASSERT(nh.getParam("translate", translation_config)&&nh.getParam("roll", roll_config)&& nh.getParam("pitch", pitch_config));
     for (int i = 0; i < translation_config.size(); i++)
       {
         translate_.push_back(xmlRpcGetDouble(translation_config[i]));
         roll_.push_back(xmlRpcGetDouble(roll_config[i]));
-        roll_.push_back(xmlRpcGetDouble(pitch_config[i]));
+        pitch_.push_back(xmlRpcGetDouble(pitch_config[i]));
       }
     pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -106,149 +106,73 @@ protected:
   ros::Publisher pub_;
   MsgType msg_;
 };
+
 class MultiDofCommandSender
 {
 public:
-  explicit MultiDofCommandSender(ros::NodeHandle& nh)
-  {
-    uint32_t queue_size = getParam(nh, "queue_size", 1);
-    ros::NodeHandle nh_pid_zero = ros::NodeHandle(nh, "pid_zero");
-    std::string topic_joint1, topic_joint2, topic_joint3, topic_joint4;
-    XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
-    ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
-               nh.getParam("reversal_max_speed", reversal_max_speed_));
-    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1) && nh.getParam("topic_joint2", topic_joint2) &&
-               nh.getParam("topic_joint3", topic_joint3) && nh.getParam("topic_joint4", topic_joint4));
-    if (nh.getParam("roll", roll_config))
+    explicit MultiDofCommandSender(ros::NodeHandle& nh)
     {
-      for (int i = 0; i < roll_config.size(); ++i)
-        roll_config_.push_back(xmlRpcGetDouble(roll_config[i]));
-      ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
-      pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
-    }
-    else
+        uint32_t queue_size = getParam(nh, "queue_size", 1);
+        XmlRpc::XmlRpcValue config{};
+        std::vector<std::string> topic_names{"topic_joint1", "topic_joint2", "topic_joint3", "topic_joint4"};
+        std::vector<std::string> topics{"topic1", "topic2", "topic3", "topic4"};
+        std::vector<std::string> config_names{"roll_config", "pitch_config", "yaw_config", "x_config", "y_config", "z_config"};
+        std::vector<std::string> pid_names{"pid_roll", "pid_pitch", "pid_yaw", "pid_x", "pid_y", "pid_z"};
+        configs_ = {roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_};
+        ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) && nh.getParam("reversal_max_speed", reversal_max_speed_));
+        for (int i = 0; i < topics.size(); ++i)
+        {
+            ROS_ASSERT(nh.getParam(topic_names[i], topics[i]));
+            pubs_[i] = nh.advertise<std_msgs::Float64>(topics[i], queue_size);
+        }
+        for (int i = 0; i < config_names.size(); ++i) {
+            if (nh.getParam(config_names[i], config)) {
+                for (int j = 0; i < configs_[i].size(); ++j)
+                    configs_[i].push_back(xmlRpcGetDouble(config[j]));
+            }
+        }
+        for (int i = 0; i < pid_names.size(); ++i)
+            pids_[i].init(ros::NodeHandle(nh, pid_names[i]),"pid");
+    };
+    void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y, double error_z, ros::Duration period)
     {
-      roll_config_ = { 0., 0., 0., 0. };
-      pid_roll_.init(ros::NodeHandle(nh_pid_zero, "pid"));
+        std::vector<double> scales{pids_[0].computeCommand(error_roll, period), pids_[1].computeCommand(error_pitch, period),
+                                   pids_[2].computeCommand(error_yaw, period), pids_[3].computeCommand(error_x, period), pids_[4].computeCommand(error_y, period),
+                                   pids_[5].computeCommand(error_z, period)};
+        setGroupVel(scales[0],scales[1],scales[2],scales[3],scales[4],scales[5]);
     }
-    if (nh.getParam("pitch", pitch_config))
+    void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,double z_scale)
     {
-      for (int i = 0; i < pitch_config.size(); ++i)
-        pitch_config_.push_back(xmlRpcGetDouble(pitch_config[i]));
-      ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
-      pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
+        std::vector<double> scales = {roll_scale,pitch_scale,yaw_scale,x_scale,y_scale,z_scale};
+        for (int i = 0; i < msgs_.size(); ++i) {
+            for (int j = 0; j < configs_.size()/2; ++j)
+                msgs_[i].data += reversal_max_speed_ * configs_[j][i] * scales[j] ;
+            for (int j = configs_.size()/2; j < configs_.size(); ++j)
+                msgs_[i].data += translate_max_speed_ * configs_[j][i] * scales[j];
+        }
     }
-    else
+    void setZero()
     {
-      pitch_config_ = { 0., 0., 0., 0. };
-      pid_pitch_.init(ros::NodeHandle(nh_pid_zero, "pid"));
+        for (int i = 0; i < msgs_.size(); ++i)
+            msgs_[i].data = 0;
     }
-    if (nh.getParam("yaw", yaw_config))
+    void sendCommand()
     {
-      for (int i = 0; i < yaw_config.size(); ++i)
-        yaw_config_.push_back(xmlRpcGetDouble(yaw_config[i]));
-      ros::NodeHandle nh_pid_yaw = ros::NodeHandle(nh, "pid_yaw");
-      pid_yaw_.init(ros::NodeHandle(nh_pid_yaw, "pid"));
+        for (int i = 0; i < pubs_.size(); ++i)
+            pubs_[i].publish(msgs_[i]);
     }
-    else
-    {
-      yaw_config_ = { 0., 0., 0., 0. };
-      pid_yaw_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-    }
-    if (nh.getParam("x", x_config))
-    {
-      for (int i = 0; i < x_config.size(); ++i)
-        x_config_.push_back(xmlRpcGetDouble(x_config[i]));
-      ros::NodeHandle nh_pid_x = ros::NodeHandle(nh, "pid_x");
-      pid_x_.init(ros::NodeHandle(nh_pid_x, "pid"));
-    }
-    else
-    {
-      x_config_ = { 0., 0., 0., 0. };
-      pid_x_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-    }
-    if (nh.getParam("y", y_config))
-    {
-      for (int i = 0; i < y_config.size(); ++i)
-        y_config_.push_back(xmlRpcGetDouble(y_config[i]));
-      ros::NodeHandle nh_pid_y = ros::NodeHandle(nh, "pid_y");
-      pid_y_.init(ros::NodeHandle(nh_pid_y, "pid"));
-    }
-    else
-    {
-      y_config_ = { 0., 0., 0., 0. };
-      pid_y_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-    }
-    if (nh.getParam("z", z_config))
-    {
-      for (int i = 0; i < z_config.size(); ++i)
-        z_config_.push_back(xmlRpcGetDouble(z_config[i]));
-      ros::NodeHandle nh_pid_z = ros::NodeHandle(nh, "pid_z");
-      pid_z_.init(ros::NodeHandle(nh_pid_z, "pid"));
-    }
-    else
-    {
-      z_config_ = { 0., 0., 0., 0. };
-      pid_z_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-    }
-    pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1, queue_size);
-    pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2, queue_size);
-    pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3, queue_size);
-    pub_joint4_ = nh.advertise<std_msgs::Float64>(topic_joint4, queue_size);
-  };
-  void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
-                      double error_z, ros::Duration period)
-  {
-    double roll_scale = pid_roll_.computeCommand(error_roll, period);
-    double pitch_scale = pid_pitch_.computeCommand(error_pitch, period);
-    double yaw_scale = pid_yaw_.computeCommand(error_yaw, period);
-    double x_scale = pid_x_.computeCommand(error_x, period);
-    double y_scale = pid_y_.computeCommand(error_y, period);
-    double z_scale = pid_z_.computeCommand(error_z, period);
-    setGroupVel(roll_scale, pitch_scale, yaw_scale, x_scale, y_scale, z_scale);
-  }
-  void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
-                   double z_scale)
-  {
-    msg_joint1_.data =
-        reversal_max_speed_ *
-            ((roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) + (yaw_config_[0] * yaw_scale)) +
-        translate_max_speed_ * ((x_config_[0] * x_scale) + (y_config_[0] * y_scale) + (z_config_[0] * z_scale));
-    msg_joint2_.data =
-        reversal_max_speed_ *
-            ((roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) + (yaw_config_[1] * yaw_scale)) +
-        translate_max_speed_ * ((x_config_[1] * x_scale) + (y_config_[1] * y_scale) + (z_config_[1] * z_scale));
-    msg_joint3_.data =
-        reversal_max_speed_ *
-            ((roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) + (yaw_config_[2] * yaw_scale)) +
-        translate_max_speed_ * ((x_config_[2] * x_scale) + (y_config_[2] * y_scale) + (z_config_[2] * z_scale));
-    msg_joint4_.data =
-        reversal_max_speed_ *
-            ((roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) + (yaw_config_[3] * yaw_scale)) +
-        translate_max_speed_ * ((x_config_[3] * x_scale) + (y_config_[3] * y_scale) + (z_config_[3] * z_scale));
-  }
-  void setZero()
-  {
-    msg_joint1_.data = 0;
-    msg_joint2_.data = 0;
-    msg_joint3_.data = 0;
-    msg_joint4_.data = 0;
-  }
-  void sendCommand()
-  {
-    pub_joint1_.publish(msg_joint1_);
-    pub_joint2_.publish(msg_joint2_);
-    pub_joint3_.publish(msg_joint3_);
-    pub_joint4_.publish(msg_joint4_);
-  }
 
 protected:
-  double reversal_max_speed_, translate_max_speed_;
-  ros::Publisher pub_joint1_, pub_joint2_, pub_joint3_, pub_joint4_;
-  std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
-  std_msgs::Float64 msg_joint1_{}, msg_joint2_{}, msg_joint3_{}, msg_joint4_{};
-  control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
+    std::vector<control_toolbox::Pid> pids_ = std::vector<control_toolbox::Pid>(6);
+    control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
+    std::vector<std::vector<double>> configs_{6};
+    std::vector<ros::Publisher> pubs_{4};
+    std::vector<std_msgs::Float64> msgs_{4};
+    std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
+    double translate_max_speed_;
+    double reversal_max_speed_;
 };
+
 
 template <class MsgType>
 class TimeStampCommandSenderBase : public CommandSenderBase<MsgType>

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -192,7 +192,10 @@ public:
       msg_r_r_.data = translate_vel_ * translate_[3] * input;
     }
     else if (roll_scales + pitch_scales + translation_scales == 0)
-      setZero();
+    {
+      msg_p_f_.data = translate_vel_ * translate_[0] * -0.1;
+      msg_p_b_.data = translate_vel_ * translate_[1] * -0.1;
+    }
   }
 
   void sendCommand()

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -109,145 +109,145 @@ protected:
 class MultiDofCommandSender
 {
 public:
-    explicit MultiDofCommandSender(ros::NodeHandle& nh)
+  explicit MultiDofCommandSender(ros::NodeHandle& nh)
+  {
+    uint32_t queue_size = getParam(nh, "queue_size", 1);
+    ros::NodeHandle nh_pid_zero = ros::NodeHandle(nh, "pid_zero");
+    std::string topic_joint1, topic_joint2, topic_joint3, topic_joint4;
+    XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
+    ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
+               nh.getParam("reversal_max_speed", reversal_max_speed_));
+    ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1) && nh.getParam("topic_joint2", topic_joint2) &&
+               nh.getParam("topic_joint3", topic_joint3) && nh.getParam("topic_joint4", topic_joint4));
+    if (nh.getParam("roll", roll_config))
     {
-        uint32_t queue_size = getParam(nh, "queue_size", 1);
-        ros::NodeHandle nh_pid_zero = ros::NodeHandle(nh, "pid_zero");
-        std::string topic_joint1, topic_joint2, topic_joint3, topic_joint4;
-        XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
-        ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&
-                   nh.getParam("reversal_max_speed", reversal_max_speed_));
-        ROS_ASSERT(nh.getParam("topic_joint1", topic_joint1) && nh.getParam("topic_joint2", topic_joint2) &&
-                   nh.getParam("topic_joint3", topic_joint3) && nh.getParam("topic_joint4", topic_joint4));
-        if (nh.getParam("roll", roll_config))
-        {
-            for (int i = 0; i < roll_config.size(); ++i)
-                roll_config_.push_back(xmlRpcGetDouble(roll_config[i]));
-            ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
-            pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
-        }
-        else
-        {
-            roll_config_ = { 0., 0., 0., 0. };
-            pid_roll_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-        }
-        if (nh.getParam("pitch", pitch_config))
-        {
-            for (int i = 0; i < pitch_config.size(); ++i)
-                pitch_config_.push_back(xmlRpcGetDouble(pitch_config[i]));
-            ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
-            pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
-        }
-        else
-        {
-            pitch_config_ = { 0., 0., 0., 0. };
-            pid_pitch_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-        }
-        if (nh.getParam("yaw", yaw_config))
-        {
-            for (int i = 0; i < yaw_config.size(); ++i)
-                yaw_config_.push_back(xmlRpcGetDouble(yaw_config[i]));
-            ros::NodeHandle nh_pid_yaw = ros::NodeHandle(nh, "pid_yaw");
-            pid_yaw_.init(ros::NodeHandle(nh_pid_yaw, "pid"));
-        }
-        else
-        {
-            yaw_config_ = { 0., 0., 0., 0. };
-            pid_yaw_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-        }
-        if (nh.getParam("x", x_config))
-        {
-            for (int i = 0; i < x_config.size(); ++i)
-                x_config_.push_back(xmlRpcGetDouble(x_config[i]));
-            ros::NodeHandle nh_pid_x = ros::NodeHandle(nh, "pid_x");
-            pid_x_.init(ros::NodeHandle(nh_pid_x, "pid"));
-        }
-        else
-        {
-            x_config_ = { 0., 0., 0., 0. };
-            pid_x_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-        }
-        if (nh.getParam("y", y_config))
-        {
-            for (int i = 0; i < y_config.size(); ++i)
-                y_config_.push_back(xmlRpcGetDouble(y_config[i]));
-            ros::NodeHandle nh_pid_y = ros::NodeHandle(nh, "pid_y");
-            pid_y_.init(ros::NodeHandle(nh_pid_y, "pid"));
-        }
-        else
-        {
-            y_config_ = { 0., 0., 0., 0. };
-            pid_y_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-        }
-        if (nh.getParam("z", z_config))
-        {
-            for (int i = 0; i < z_config.size(); ++i)
-                z_config_.push_back(xmlRpcGetDouble(z_config[i]));
-            ros::NodeHandle nh_pid_z = ros::NodeHandle(nh, "pid_z");
-            pid_z_.init(ros::NodeHandle(nh_pid_z, "pid"));
-        }
-        else
-        {
-            z_config_ = { 0., 0., 0., 0. };
-            pid_z_.init(ros::NodeHandle(nh_pid_zero, "pid"));
-        }
-        pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1, queue_size);
-        pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2, queue_size);
-        pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3, queue_size);
-        pub_joint4_ = nh.advertise<std_msgs::Float64>(topic_joint4, queue_size);
-    };
-    void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
-                        double error_z, ros::Duration period)
-    {
-        double roll_scale = pid_roll_.computeCommand(error_roll, period);
-        double pitch_scale = pid_pitch_.computeCommand(error_pitch, period);
-        double yaw_scale = pid_yaw_.computeCommand(error_yaw, period);
-        double x_scale = pid_x_.computeCommand(error_x, period);
-        double y_scale = pid_y_.computeCommand(error_y, period);
-        double z_scale = pid_z_.computeCommand(error_z, period);
-        setGroupVel(roll_scale, pitch_scale, yaw_scale, x_scale, y_scale, z_scale);
+      for (int i = 0; i < roll_config.size(); ++i)
+        roll_config_.push_back(xmlRpcGetDouble(roll_config[i]));
+      ros::NodeHandle nh_pid_roll = ros::NodeHandle(nh, "pid_roll");
+      pid_roll_.init(ros::NodeHandle(nh_pid_roll, "pid"));
     }
-    void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
-                     double z_scale)
+    else
     {
-        msg_joint1_.data =
-                reversal_max_speed_ *
-                ((roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) + (yaw_config_[0] * yaw_scale)) +
-                translate_max_speed_ * ((x_config_[0] * x_scale) + (y_config_[0] * y_scale) + (z_config_[0] * z_scale));
-        msg_joint2_.data =
-                reversal_max_speed_ *
-                ((roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) + (yaw_config_[1] * yaw_scale)) +
-                translate_max_speed_ * ((x_config_[1] * x_scale) + (y_config_[1] * y_scale) + (z_config_[1] * z_scale));
-        msg_joint3_.data =
-                reversal_max_speed_ *
-                ((roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) + (yaw_config_[2] * yaw_scale)) +
-                translate_max_speed_ * ((x_config_[2] * x_scale) + (y_config_[2] * y_scale) + (z_config_[2] * z_scale));
-        msg_joint4_.data =
-                reversal_max_speed_ *
-                ((roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) + (yaw_config_[3] * yaw_scale)) +
-                translate_max_speed_ * ((x_config_[3] * x_scale) + (y_config_[3] * y_scale) + (z_config_[3] * z_scale));
+      roll_config_ = { 0., 0., 0., 0. };
+      pid_roll_.init(ros::NodeHandle(nh_pid_zero, "pid"));
     }
-    void setZero()
+    if (nh.getParam("pitch", pitch_config))
     {
-        msg_joint1_.data = 0;
-        msg_joint2_.data = 0;
-        msg_joint3_.data = 0;
-        msg_joint4_.data = 0;
+      for (int i = 0; i < pitch_config.size(); ++i)
+        pitch_config_.push_back(xmlRpcGetDouble(pitch_config[i]));
+      ros::NodeHandle nh_pid_pitch = ros::NodeHandle(nh, "pid_pitch");
+      pid_pitch_.init(ros::NodeHandle(nh_pid_pitch, "pid"));
     }
-    void sendCommand()
+    else
     {
-        pub_joint1_.publish(msg_joint1_);
-        pub_joint2_.publish(msg_joint2_);
-        pub_joint3_.publish(msg_joint3_);
-        pub_joint4_.publish(msg_joint4_);
+      pitch_config_ = { 0., 0., 0., 0. };
+      pid_pitch_.init(ros::NodeHandle(nh_pid_zero, "pid"));
     }
+    if (nh.getParam("yaw", yaw_config))
+    {
+      for (int i = 0; i < yaw_config.size(); ++i)
+        yaw_config_.push_back(xmlRpcGetDouble(yaw_config[i]));
+      ros::NodeHandle nh_pid_yaw = ros::NodeHandle(nh, "pid_yaw");
+      pid_yaw_.init(ros::NodeHandle(nh_pid_yaw, "pid"));
+    }
+    else
+    {
+      yaw_config_ = { 0., 0., 0., 0. };
+      pid_yaw_.init(ros::NodeHandle(nh_pid_zero, "pid"));
+    }
+    if (nh.getParam("x", x_config))
+    {
+      for (int i = 0; i < x_config.size(); ++i)
+        x_config_.push_back(xmlRpcGetDouble(x_config[i]));
+      ros::NodeHandle nh_pid_x = ros::NodeHandle(nh, "pid_x");
+      pid_x_.init(ros::NodeHandle(nh_pid_x, "pid"));
+    }
+    else
+    {
+      x_config_ = { 0., 0., 0., 0. };
+      pid_x_.init(ros::NodeHandle(nh_pid_zero, "pid"));
+    }
+    if (nh.getParam("y", y_config))
+    {
+      for (int i = 0; i < y_config.size(); ++i)
+        y_config_.push_back(xmlRpcGetDouble(y_config[i]));
+      ros::NodeHandle nh_pid_y = ros::NodeHandle(nh, "pid_y");
+      pid_y_.init(ros::NodeHandle(nh_pid_y, "pid"));
+    }
+    else
+    {
+      y_config_ = { 0., 0., 0., 0. };
+      pid_y_.init(ros::NodeHandle(nh_pid_zero, "pid"));
+    }
+    if (nh.getParam("z", z_config))
+    {
+      for (int i = 0; i < z_config.size(); ++i)
+        z_config_.push_back(xmlRpcGetDouble(z_config[i]));
+      ros::NodeHandle nh_pid_z = ros::NodeHandle(nh, "pid_z");
+      pid_z_.init(ros::NodeHandle(nh_pid_z, "pid"));
+    }
+    else
+    {
+      z_config_ = { 0., 0., 0., 0. };
+      pid_z_.init(ros::NodeHandle(nh_pid_zero, "pid"));
+    }
+    pub_joint1_ = nh.advertise<std_msgs::Float64>(topic_joint1, queue_size);
+    pub_joint2_ = nh.advertise<std_msgs::Float64>(topic_joint2, queue_size);
+    pub_joint3_ = nh.advertise<std_msgs::Float64>(topic_joint3, queue_size);
+    pub_joint4_ = nh.advertise<std_msgs::Float64>(topic_joint4, queue_size);
+  };
+  void visionReversal(double error_roll, double error_pitch, double error_yaw, double error_x, double error_y,
+                      double error_z, ros::Duration period)
+  {
+    double roll_scale = pid_roll_.computeCommand(error_roll, period);
+    double pitch_scale = pid_pitch_.computeCommand(error_pitch, period);
+    double yaw_scale = pid_yaw_.computeCommand(error_yaw, period);
+    double x_scale = pid_x_.computeCommand(error_x, period);
+    double y_scale = pid_y_.computeCommand(error_y, period);
+    double z_scale = pid_z_.computeCommand(error_z, period);
+    setGroupVel(roll_scale, pitch_scale, yaw_scale, x_scale, y_scale, z_scale);
+  }
+  void setGroupVel(double roll_scale, double pitch_scale, double yaw_scale, double x_scale, double y_scale,
+                   double z_scale)
+  {
+    msg_joint1_.data =
+        reversal_max_speed_ *
+            ((roll_config_[0] * roll_scale) + (pitch_config_[0] * pitch_scale) + (yaw_config_[0] * yaw_scale)) +
+        translate_max_speed_ * ((x_config_[0] * x_scale) + (y_config_[0] * y_scale) + (z_config_[0] * z_scale));
+    msg_joint2_.data =
+        reversal_max_speed_ *
+            ((roll_config_[1] * roll_scale) + (pitch_config_[1] * pitch_scale) + (yaw_config_[1] * yaw_scale)) +
+        translate_max_speed_ * ((x_config_[1] * x_scale) + (y_config_[1] * y_scale) + (z_config_[1] * z_scale));
+    msg_joint3_.data =
+        reversal_max_speed_ *
+            ((roll_config_[2] * roll_scale) + (pitch_config_[2] * pitch_scale) + (yaw_config_[2] * yaw_scale)) +
+        translate_max_speed_ * ((x_config_[2] * x_scale) + (y_config_[2] * y_scale) + (z_config_[2] * z_scale));
+    msg_joint4_.data =
+        reversal_max_speed_ *
+            ((roll_config_[3] * roll_scale) + (pitch_config_[3] * pitch_scale) + (yaw_config_[3] * yaw_scale)) +
+        translate_max_speed_ * ((x_config_[3] * x_scale) + (y_config_[3] * y_scale) + (z_config_[3] * z_scale));
+  }
+  void setZero()
+  {
+    msg_joint1_.data = 0;
+    msg_joint2_.data = 0;
+    msg_joint3_.data = 0;
+    msg_joint4_.data = 0;
+  }
+  void sendCommand()
+  {
+    pub_joint1_.publish(msg_joint1_);
+    pub_joint2_.publish(msg_joint2_);
+    pub_joint3_.publish(msg_joint3_);
+    pub_joint4_.publish(msg_joint4_);
+  }
 
 protected:
-    double reversal_max_speed_, translate_max_speed_;
-    ros::Publisher pub_joint1_, pub_joint2_, pub_joint3_, pub_joint4_;
-    std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
-    std_msgs::Float64 msg_joint1_{}, msg_joint2_{}, msg_joint3_{}, msg_joint4_{};
-    control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
+  double reversal_max_speed_, translate_max_speed_;
+  ros::Publisher pub_joint1_, pub_joint2_, pub_joint3_, pub_joint4_;
+  std::vector<double> roll_config_, pitch_config_, yaw_config_, x_config_, y_config_, z_config_;
+  std_msgs::Float64 msg_joint1_{}, msg_joint2_{}, msg_joint3_{}, msg_joint4_{};
+  control_toolbox::Pid pid_roll_, pid_pitch_, pid_yaw_, pid_x_, pid_y_, pid_z_;
 };
 
 template <class MsgType>

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -112,7 +112,6 @@ public:
   explicit MultiDofCommandSender(ros::NodeHandle& nh)
   {
     uint32_t queue_size = getParam(nh, "queue_size", 1);
-    ;
     std::string topic_joint1, topic_joint2, topic_joint3, topic_joint4;
     XmlRpc::XmlRpcValue roll_config{}, pitch_config{}, yaw_config{}, x_config{}, y_config{}, z_config{};
     ROS_ASSERT(nh.getParam("translate_max_speed", translate_max_speed_) &&

--- a/rm_common/package.xml
+++ b/rm_common/package.xml
@@ -21,6 +21,7 @@
     <depend>dynamic_reconfigure</depend>
     <depend>eigen</depend>
     <depend>control_msgs</depend>
+    <depend>control_toolbox</depend>
     <depend>controller_manager_msgs</depend>
 
     <!-- The export tag contains other, unspecified, tags -->

--- a/rm_msgs/CMakeLists.txt
+++ b/rm_msgs/CMakeLists.txt
@@ -24,6 +24,7 @@ add_message_files(
         SuperCapacitor.msg
         GpioData.msg
         TofRadarData.msg
+        ReversalCmd.msg
 )
 
 add_service_files(

--- a/rm_msgs/msg/ReversalCmd.msg
+++ b/rm_msgs/msg/ReversalCmd.msg
@@ -1,0 +1,2 @@
+float64 error
+int8 mode


### PR DESCRIPTION
旧版的reversalcommandsender缺点：
     仅仅针对与当前工程的翻转机构（将矿石进行roll和pitch翻转，z轴平移），当工程翻转机构稍有改变时就需要把代码内部名字都改一遍，十分麻烦。
修改的MulitDofcommandsender（四个电机可以改变刚体进行多自由度的运动所以起这个名）：
    考虑六个自由度，根据配置文件选择其中几个。
目前问题：代码很丑
    将在后面进行优化（自己想不出，想听听大家有什么好的建议）