### PR TITLE
Fix imu problem in gazebo simulation.

### DIFF
--- a/rm_gazebo/include/rm_gazebo/rm_robot_hw_sim.h
+++ b/rm_gazebo/include/rm_gazebo/rm_robot_hw_sim.h
@@ -79,7 +79,7 @@ private:
   hardware_interface::ImuSensorInterface imu_sensor_interface_;
   rm_control::RmImuSensorInterface rm_imu_sensor_interface_;
   gazebo::physics::WorldPtr world_;
-  std::vector<ImuData> imu_datas_;
+  std::list<ImuData> imu_datas_;
   ros::ServiceServer switch_imu_service_;
   static bool disable_imu_;
 };

--- a/rm_gazebo/src/rm_robot_hw_sim.cpp
+++ b/rm_gazebo/src/rm_robot_hw_sim.cpp
@@ -97,6 +97,7 @@ void RmRobotHWSim::readSim(ros::Time time, ros::Duration period)
 void RmRobotHWSim::parseImu(XmlRpc::XmlRpcValue& imu_datas, const gazebo::physics::ModelPtr& parent_model)
 {
   ROS_ASSERT(imu_datas.getType() == XmlRpc::XmlRpcValue::TypeStruct);
+  imu_datas_.reserve(imu_datas.size());
   for (auto it = imu_datas.begin(); it != imu_datas.end(); ++it)
   {
     if (!it->second.hasMember("frame_id"))

--- a/rm_gazebo/src/rm_robot_hw_sim.cpp
+++ b/rm_gazebo/src/rm_robot_hw_sim.cpp
@@ -97,7 +97,6 @@ void RmRobotHWSim::readSim(ros::Time time, ros::Duration period)
 void RmRobotHWSim::parseImu(XmlRpc::XmlRpcValue& imu_datas, const gazebo::physics::ModelPtr& parent_model)
 {
   ROS_ASSERT(imu_datas.getType() == XmlRpc::XmlRpcValue::TypeStruct);
-  imu_datas_.reserve(imu_datas.size());
   for (auto it = imu_datas.begin(); it != imu_datas.end(); ++it)
   {
     if (!it->second.hasMember("frame_id"))


### PR DESCRIPTION
在gazebo对平衡步兵的仿真中会出现当有两块imu时，其中一块的数据会始终是0的情况，在排除是urdf本身的错误后开始排查代码。

chassis controller会向interface获取base imu的handle，这个handle的数据会在rm_gazebo包内的readSim()函数内更新。检查变量地址后发现函数内更新的变量内存地址和handle尝试读取的内存的地址不一样

经过[c++查询](https://en.cppreference.com/w/cpp/container/vector)，发现vector容器的元素内存地址会在程序的运行中进行随机分配


> “The storage of the vector is handled automatically, being expanded as needed. Vectors usually occupy more space than static arrays, because more memory is allocated to handle future growth. This way a vector does not need to reallocate each time an element is inserted, but only when the additional memory is exhausted. The total amount of allocated memory can be queried using capacity() function. Extra memory can be returned to the system via a call to shrink_to_fit(). (since C++11)”


原文中提到“This way a vector does not need to reallocate each time an element is inserted“，说明vector容器的元素内存地址会在插入元素后重新分配。

不过有意思的是第一个元素地址并不会变化，这也就导致了从第二个元素开始才会有问题。

通过与can bus的数据存储比较，发现can数据使用map容器存储，这也许是can数据不会有问题的原因。

解决方案一：使用动态内存分配，imu容器内部元素类型为指针，尽管指针变量的地址会变，但其指向仍是动态分配的内存地址

解决方案二：使用reserve()函数，在vector插入元素前预分配足够的内存，避免元素内存地址在插入元素后随机分配

解决方案三：使用list类型替代(目前采用的方案)

以上三种方案都通过了测试