### PR TITLE
Add a function in the shooter command sender to get the current mode.

### DIFF
--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -381,6 +381,10 @@ public:
   {
     return heat_limit_->getShootFrequencyMode();
   }
+  uint8_t getMode()
+  {
+    return msg_.mode;
+  }
   void setZero() override{};
   HeatLimit* heat_limit_{};
 


### PR DESCRIPTION
在ShooterCommandSender这个类中增加一个函数用于获取shooter当前的模式