### PR TITLE
Delete armor flash ui.

### DIFF
--- a/rm_referee/include/rm_referee/referee_base.h
+++ b/rm_referee/include/rm_referee/referee_base.h
@@ -73,7 +73,6 @@ public:
 
   CoverFlashUi* cover_flash_ui_{};
   SpinFlashUi* spin_flash_ui_{};
-  ArmorFlashUi *armor0_flash_ui_{}, *armor1_flash_ui_{}, *armor2_flash_ui_{}, *armor3_flash_ui_{};
 
   Base& base_;
   bool add_ui_flag_ = false;

--- a/rm_referee/include/rm_referee/ui/flash_ui.h
+++ b/rm_referee/include/rm_referee/ui/flash_ui.h
@@ -19,25 +19,6 @@ public:
   virtual void updateConfig(){};
 };
 
-class ArmorFlashUi : public FlashUi
-{
-public:
-  explicit ArmorFlashUi(XmlRpc::XmlRpcValue& rpc_value, Base& base, std::string graph_name)
-    : FlashUi(rpc_value, base, graph_name)
-  {
-    graph_name_ = graph_name;
-  };
-  void updateRobotHurtData(const rm_msgs::RobotHurt data, const ros::Time& last_get_data_time);
-
-private:
-  void display(const ros::Time& time) override;
-  void updateArmorPosition();
-  uint8_t getArmorId();
-
-  std::string graph_name_;
-  uint8_t hurt_type_, armor_id_;
-};
-
 class CoverFlashUi : public FlashUi
 {
 public:

--- a/rm_referee/src/referee_base.cpp
+++ b/rm_referee/src/referee_base.cpp
@@ -70,14 +70,6 @@ RefereeBase::RefereeBase(ros::NodeHandle& nh, Base& base) : base_(base), nh_(nh)
       cover_flash_ui_ = new CoverFlashUi(rpc_value[i], base_);
     if (rpc_value[i]["name"] == "spin")
       spin_flash_ui_ = new SpinFlashUi(rpc_value[i], base_);
-    if (rpc_value[i]["name"] == "armor0")
-      armor0_flash_ui_ = new ArmorFlashUi(rpc_value[i], base_, "armor0");
-    if (rpc_value[i]["name"] == "armor1")
-      armor1_flash_ui_ = new ArmorFlashUi(rpc_value[i], base_, "armor1");
-    if (rpc_value[i]["name"] == "armor2")
-      armor2_flash_ui_ = new ArmorFlashUi(rpc_value[i], base_, "armor2");
-    if (rpc_value[i]["name"] == "armor3")
-      armor3_flash_ui_ = new ArmorFlashUi(rpc_value[i], base_, "armor3");
   }
 }
 void RefereeBase::addUi()
@@ -124,14 +116,6 @@ void RefereeBase::powerHeatDataCallBack(const rm_msgs::PowerHeatData& data, cons
 }
 void RefereeBase::robotHurtDataCallBack(const rm_msgs::RobotHurt& data, const ros::Time& last_get_data_time)
 {
-  if (armor0_flash_ui_)
-    armor0_flash_ui_->updateRobotHurtData(data, last_get_data_time);
-  if (armor1_flash_ui_)
-    armor1_flash_ui_->updateRobotHurtData(data, last_get_data_time);
-  if (armor2_flash_ui_)
-    armor2_flash_ui_->updateRobotHurtData(data, last_get_data_time);
-  if (armor3_flash_ui_)
-    armor3_flash_ui_->updateRobotHurtData(data, last_get_data_time);
 }
 void RefereeBase::interactiveDataCallBack(const rm_referee::InteractiveData& data, const ros::Time& last_get_data_time)
 {

--- a/rm_referee/src/ui/flash_ui.cpp
+++ b/rm_referee/src/ui/flash_ui.cpp
@@ -6,66 +6,6 @@
 
 namespace rm_referee
 {
-void ArmorFlashUi::display(const ros::Time& time)
-{
-  if (hurt_type_ == 0x00 && armor_id_ == getArmorId())
-  {
-    updateArmorPosition();
-    graph_->display(time, true, true);
-    graph_->sendUi(time);
-    hurt_type_ = 9;
-  }
-  else
-  {
-    graph_->display(time, false, true);
-    graph_->sendUi(time);
-  }
-}
-
-void ArmorFlashUi::updateArmorPosition()
-{
-  geometry_msgs::TransformStamped yaw2base;
-  double roll, pitch, yaw;
-  try
-  {
-    yaw2base = tf_buffer_.lookupTransform("yaw", "base_link", ros::Time(0));
-  }
-  catch (tf2::TransformException& ex)
-  {
-  }
-  quatToRPY(yaw2base.transform.rotation, roll, pitch, yaw);
-  if (getArmorId() == 0 || getArmorId() == 2)
-  {
-    graph_->setStartX(static_cast<int>((960 + 340 * sin(getArmorId() * M_PI_2 + yaw))));
-    graph_->setStartY(static_cast<int>((540 + 340 * cos(getArmorId() * M_PI_2 + yaw))));
-  }
-  else
-  {
-    graph_->setStartX(static_cast<int>((960 + 340 * sin(-getArmorId() * M_PI_2 + yaw))));
-    graph_->setStartY(static_cast<int>((540 + 340 * cos(-getArmorId() * M_PI_2 + yaw))));
-  }
-}
-
-uint8_t ArmorFlashUi::getArmorId()
-{
-  if (graph_name_ == "armor0")
-    return 0;
-  else if (graph_name_ == "armor1")
-    return 1;
-  else if (graph_name_ == "armor2")
-    return 2;
-  else if (graph_name_ == "armor3")
-    return 3;
-  return 9;
-}
-
-void ArmorFlashUi::updateRobotHurtData(const rm_msgs::RobotHurt data, const ros::Time& last_get_data_time)
-{
-  hurt_type_ = data.hurt_type;
-  armor_id_ = data.armor_id;
-  display(last_get_data_time);
-}
-
 void CoverFlashUi::display(const ros::Time& time)
 {
   if (!cover_state_)


### PR DESCRIPTION
根据操作手的实际反馈删除了装甲板的受击显示ui。
删除该ui的另一个原因是因为随着操作手客户端的更新，ui的刷新能力在测试中急剧下降，大量ui无法刷出或及时更新，受击显示的ui会因为无法及时擦除而残留在屏幕上干扰视野。目前仍在思考如何解决这个问题。