### PR TITLE
Fixed bug in burst model

### DIFF
--- a/rm_common/include/rm_common/decision/power_limit.h
+++ b/rm_common/include/rm_common/decision/power_limit.h
@@ -176,7 +176,7 @@ private:
         chassis_cmd.power_limit = burst_power_;
     }
     else
-      chassis_cmd.power_limit = chassis_power_limit_;
+      normal(chassis_cmd);
   }
 
   int game_progress_;


### PR DESCRIPTION
当进burst状态时可能会出现无法吃到缓存的状况，现在将计算过程直接替换为normal().