### PR TITLE
Fixed bug in graph queue update

### DIFF
--- a/rm_referee/src/ui/time_change_ui.cpp
+++ b/rm_referee/src/ui/time_change_ui.cpp
@@ -38,15 +38,16 @@ void TimeChangeUi::updateForQueue()
 void TimeChangeGroupUi::updateForQueue()
 {
   updateConfig();
-  for (auto graph : graph_vector_)
-  {
-    graph.second->setOperation(rm_referee::GraphOperation::UPDATE);
-    if (graph_queue_ && !graph.second->isRepeated() && ros::Time::now() - last_send_ > delay_)
+  if (ros::Time::now() - last_send_ > delay_)
+    for (auto graph : graph_vector_)
     {
-      graph_queue_->push_back(*graph.second);
-      last_send_ = ros::Time::now();
+      graph.second->setOperation(rm_referee::GraphOperation::UPDATE);
+      if (graph_queue_ && !graph.second->isRepeated())
+      {
+        graph_queue_->push_back(*graph.second);
+        last_send_ = ros::Time::now();
+      }
     }
-  }
 }
 
 void CapacitorTimeChangeUi::add()


### PR DESCRIPTION
解决一个ui队列更新时更新时间戳的bug，在group ui中会触发。