### PR TITLE
Supplement the missing message file in CMakeLists.txt

### DIFF
--- a/rm_msgs/CMakeLists.txt
+++ b/rm_msgs/CMakeLists.txt
@@ -25,6 +25,8 @@ add_message_files(
         GpioData.msg
         TofRadarData.msg
         MultiDofCmd.msg
+        TagMsg.msg
+        TagMsgArray.msg
 )
 
 add_service_files(


### PR DESCRIPTION
缺少的这两个message导致rm_localization编译失败