### PR TITLE
Modify ShootCmd add the function of adjusting the speed in the shooter command sender

### DIFF
--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -324,6 +324,7 @@ public:
     nh.getParam("qd_16", qd_16_);
     nh.getParam("qd_18", qd_18_);
     nh.getParam("qd_30", qd_30_);
+    nh.param("extra_rotate_speed_once", extra_rotate_speed_once_, 0.);
     if (!nh.getParam("gimbal_error_tolerance", gimbal_error_tolerance_))
       ROS_ERROR("gimbal error tolerance no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("target_acceleration_tolerance", target_acceleration_tolerance_))
@@ -383,7 +384,7 @@ public:
   double getQdDes()
   {
     setSpeedDesAndQdDes();
-    return qd_des_;
+    return qd_des_ + total_extra_rotate_speed_;
   }
   void setSpeedDesAndQdDes()
   {
@@ -421,6 +422,14 @@ public:
       }
     }
   }
+  void dropSpeed()
+  {
+    total_extra_rotate_speed_ -= extra_rotate_speed_once_;
+  }
+  void raiseSpeed()
+  {
+    total_extra_rotate_speed_ += extra_rotate_speed_once_;
+  }
   void setArmorType(uint8_t armor_type)
   {
     armor_type_ = armor_type;
@@ -441,6 +450,8 @@ private:
   double qd_10_{}, qd_15_{}, qd_16_{}, qd_18_{}, qd_30_{}, qd_des_{};
   double gimbal_error_tolerance_{};
   double target_acceleration_tolerance_{};
+  double extra_rotate_speed_once_{};
+  double total_extra_rotate_speed_{};
   rm_msgs::TrackData track_data_;
   rm_msgs::GimbalDesError gimbal_des_error_;
   std_msgs::Bool suggest_fire_;

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -319,6 +319,11 @@ public:
     nh.param("speed_16m_per_speed", speed_16_, 16.);
     nh.param("speed_18m_per_speed", speed_18_, 18.);
     nh.param("speed_30m_per_speed", speed_30_, 30.);
+    nh.getParam("qd_10", qd_10_);
+    nh.getParam("qd_15", qd_15_);
+    nh.getParam("qd_16", qd_16_);
+    nh.getParam("qd_18", qd_18_);
+    nh.getParam("qd_30", qd_30_);
     if (!nh.getParam("gimbal_error_tolerance", gimbal_error_tolerance_))
       ROS_ERROR("gimbal error tolerance no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("target_acceleration_tolerance", target_acceleration_tolerance_))
@@ -366,26 +371,51 @@ public:
   }
   void sendCommand(const ros::Time& time) override
   {
-    msg_.speed = heat_limit_->getSpeedLimit();
+    msg_.qd_des = getQdDes();
     msg_.hz = heat_limit_->getShootFrequency();
     TimeStampCommandSenderBase<rm_msgs::ShootCmd>::sendCommand(time);
   }
   double getSpeed()
   {
-    switch (msg_.speed)
+    setSpeedDesAndQdDes();
+    return speed_des_;
+  }
+  double getQdDes()
+  {
+    setSpeedDesAndQdDes();
+    return qd_des_;
+  }
+
+  void setSpeedDesAndQdDes()
+  {
+    switch (heat_limit_->getSpeedLimit())
     {
       case rm_msgs::ShootCmd::SPEED_10M_PER_SECOND:
-        return speed_10_;
+      {
+        speed_des_ = speed_10_;
+        qd_des_ = qd_10_;
+      }
       case rm_msgs::ShootCmd::SPEED_15M_PER_SECOND:
-        return speed_15_;
+      {
+        speed_des_ = speed_15_;
+        qd_des_ = qd_15_;
+      }
       case rm_msgs::ShootCmd::SPEED_16M_PER_SECOND:
-        return speed_16_;
+      {
+        speed_des_ = speed_16_;
+        qd_des_ = qd_16_;
+      }
       case rm_msgs::ShootCmd::SPEED_18M_PER_SECOND:
-        return speed_18_;
+      {
+        speed_des_ = speed_18_;
+        qd_des_ = qd_18_;
+      }
       case rm_msgs::ShootCmd::SPEED_30M_PER_SECOND:
-        return speed_30_;
+      {
+        speed_des_ = speed_30_;
+        qd_des_ = qd_30_;
+      }
     }
-    return 0.;
   }
   void setArmorType(uint8_t armor_type)
   {
@@ -403,7 +433,8 @@ public:
   HeatLimit* heat_limit_{};
 
 private:
-  double speed_10_, speed_15_, speed_16_, speed_18_, speed_30_;
+  double speed_10_, speed_15_, speed_16_, speed_18_, speed_30_, speed_des_;
+  double qd_10_, qd_15_, qd_16_, qd_18_, qd_30_, qd_des_;
   double gimbal_error_tolerance_{};
   double target_acceleration_tolerance_{};
   rm_msgs::TrackData track_data_;

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -372,7 +372,7 @@ public:
   }
   void sendCommand(const ros::Time& time) override
   {
-    msg_.wheel_speed_des = getWheelSpeedDes();
+    msg_.wheel_speed = getWheelSpeedDes();
     msg_.hz = heat_limit_->getShootFrequency();
     TimeStampCommandSenderBase<rm_msgs::ShootCmd>::sendCommand(time);
   }

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -319,12 +319,12 @@ public:
     nh.param("speed_16m_per_speed", speed_16_, 16.);
     nh.param("speed_18m_per_speed", speed_18_, 18.);
     nh.param("speed_30m_per_speed", speed_30_, 30.);
-    nh.getParam("qd_10", qd_10_);
-    nh.getParam("qd_15", qd_15_);
-    nh.getParam("qd_16", qd_16_);
-    nh.getParam("qd_18", qd_18_);
-    nh.getParam("qd_30", qd_30_);
-    nh.param("extra_rotate_speed_once", extra_rotate_speed_once_, 0.);
+    nh.getParam("wheel_speed_10", wheel_speed_10_);
+    nh.getParam("wheel_speed_15", wheel_speed_15_);
+    nh.getParam("wheel_speed_16", wheel_speed_16_);
+    nh.getParam("wheel_speed_18", wheel_speed_18_);
+    nh.getParam("wheel_speed_30", wheel_speed_30_);
+    nh.param("extra_wheel_speed_once", extra_wheel_speed_once_, 0.);
     if (!nh.getParam("gimbal_error_tolerance", gimbal_error_tolerance_))
       ROS_ERROR("gimbal error tolerance no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("target_acceleration_tolerance", target_acceleration_tolerance_))
@@ -372,63 +372,63 @@ public:
   }
   void sendCommand(const ros::Time& time) override
   {
-    msg_.qd_des = getQdDes();
+    msg_.wheel_speed_des = getWheelSpeedDes();
     msg_.hz = heat_limit_->getShootFrequency();
     TimeStampCommandSenderBase<rm_msgs::ShootCmd>::sendCommand(time);
   }
   double getSpeed()
   {
-    setSpeedDesAndQdDes();
+    setSpeedDesAndWheelSpeedDes();
     return speed_des_;
   }
-  double getQdDes()
+  double getWheelSpeedDes()
   {
-    setSpeedDesAndQdDes();
-    return qd_des_ + total_extra_rotate_speed_;
+    setSpeedDesAndWheelSpeedDes();
+    return wheel_speed_des_ + total_extra_wheel_speed_;
   }
-  void setSpeedDesAndQdDes()
+  void setSpeedDesAndWheelSpeedDes()
   {
     switch (heat_limit_->getSpeedLimit())
     {
       case rm_msgs::ShootCmd::SPEED_10M_PER_SECOND:
       {
         speed_des_ = speed_10_;
-        qd_des_ = qd_10_;
+        wheel_speed_des_ = wheel_speed_10_;
         break;
       }
       case rm_msgs::ShootCmd::SPEED_15M_PER_SECOND:
       {
         speed_des_ = speed_15_;
-        qd_des_ = qd_15_;
+        wheel_speed_des_ = wheel_speed_15_;
         break;
       }
       case rm_msgs::ShootCmd::SPEED_16M_PER_SECOND:
       {
         speed_des_ = speed_16_;
-        qd_des_ = qd_16_;
+        wheel_speed_des_ = wheel_speed_16_;
         break;
       }
       case rm_msgs::ShootCmd::SPEED_18M_PER_SECOND:
       {
         speed_des_ = speed_18_;
-        qd_des_ = qd_18_;
+        wheel_speed_des_ = wheel_speed_18_;
         break;
       }
       case rm_msgs::ShootCmd::SPEED_30M_PER_SECOND:
       {
         speed_des_ = speed_30_;
-        qd_des_ = qd_30_;
+        wheel_speed_des_ = wheel_speed_30_;
         break;
       }
     }
   }
   void dropSpeed()
   {
-    total_extra_rotate_speed_ -= extra_rotate_speed_once_;
+    total_extra_wheel_speed_ -= extra_wheel_speed_once_;
   }
   void raiseSpeed()
   {
-    total_extra_rotate_speed_ += extra_rotate_speed_once_;
+    total_extra_wheel_speed_ += extra_wheel_speed_once_;
   }
   void setArmorType(uint8_t armor_type)
   {
@@ -447,11 +447,12 @@ public:
 
 private:
   double speed_10_{}, speed_15_{}, speed_16_{}, speed_18_{}, speed_30_{}, speed_des_{};
-  double qd_10_{}, qd_15_{}, qd_16_{}, qd_18_{}, qd_30_{}, qd_des_{};
+  double wheel_speed_10_{}, wheel_speed_15_{}, wheel_speed_16_{}, wheel_speed_18_{}, wheel_speed_30_{},
+      wheel_speed_des_{};
   double gimbal_error_tolerance_{};
   double target_acceleration_tolerance_{};
-  double extra_rotate_speed_once_{};
-  double total_extra_rotate_speed_{};
+  double extra_wheel_speed_once_{};
+  double total_extra_wheel_speed_{};
   rm_msgs::TrackData track_data_;
   rm_msgs::GimbalDesError gimbal_des_error_;
   std_msgs::Bool suggest_fire_;

--- a/rm_common/include/rm_common/decision/command_sender.h
+++ b/rm_common/include/rm_common/decision/command_sender.h
@@ -385,7 +385,6 @@ public:
     setSpeedDesAndQdDes();
     return qd_des_;
   }
-
   void setSpeedDesAndQdDes()
   {
     switch (heat_limit_->getSpeedLimit())
@@ -394,26 +393,31 @@ public:
       {
         speed_des_ = speed_10_;
         qd_des_ = qd_10_;
+        break;
       }
       case rm_msgs::ShootCmd::SPEED_15M_PER_SECOND:
       {
         speed_des_ = speed_15_;
         qd_des_ = qd_15_;
+        break;
       }
       case rm_msgs::ShootCmd::SPEED_16M_PER_SECOND:
       {
         speed_des_ = speed_16_;
         qd_des_ = qd_16_;
+        break;
       }
       case rm_msgs::ShootCmd::SPEED_18M_PER_SECOND:
       {
         speed_des_ = speed_18_;
         qd_des_ = qd_18_;
+        break;
       }
       case rm_msgs::ShootCmd::SPEED_30M_PER_SECOND:
       {
         speed_des_ = speed_30_;
         qd_des_ = qd_30_;
+        break;
       }
     }
   }
@@ -433,8 +437,8 @@ public:
   HeatLimit* heat_limit_{};
 
 private:
-  double speed_10_, speed_15_, speed_16_, speed_18_, speed_30_, speed_des_;
-  double qd_10_, qd_15_, qd_16_, qd_18_, qd_30_, qd_des_;
+  double speed_10_{}, speed_15_{}, speed_16_{}, speed_18_{}, speed_30_{}, speed_des_{};
+  double qd_10_{}, qd_15_{}, qd_16_{}, qd_18_{}, qd_30_{}, qd_des_{};
   double gimbal_error_tolerance_{};
   double target_acceleration_tolerance_{};
   rm_msgs::TrackData track_data_;

--- a/rm_msgs/msg/ShootCmd.msg
+++ b/rm_msgs/msg/ShootCmd.msg
@@ -10,6 +10,6 @@ uint8 SPEED_18M_PER_SECOND = 4
 uint8 SPEED_30M_PER_SECOND = 5
 
 uint8 mode
-uint8 speed
+float64 qd_des
 float64 hz
 time stamp

--- a/rm_msgs/msg/ShootCmd.msg
+++ b/rm_msgs/msg/ShootCmd.msg
@@ -10,6 +10,6 @@ uint8 SPEED_18M_PER_SECOND = 4
 uint8 SPEED_30M_PER_SECOND = 5
 
 uint8 mode
-float64 qd_des
+float64 wheel_speed
 float64 hz
 time stamp


### PR DESCRIPTION
将期望的转速值加入ShootCmd中，并在shooter commander中实现调整摩擦轮转速的功能