### PR TITLE
Update dbus communication protocol.

### DIFF
--- a/rm_dbus/include/rm_dbus/dbus.h
+++ b/rm_dbus/include/rm_dbus/dbus.h
@@ -76,6 +76,7 @@ private:
   int16_t buff_[18]{};
   bool is_success{};
   bool is_update_ = false;
+  static ros::Time last_update_time_;
   void unpack();
 };
 

--- a/rm_dbus/include/rm_dbus/dbus.h
+++ b/rm_dbus/include/rm_dbus/dbus.h
@@ -76,8 +76,7 @@ private:
   int16_t buff_[18]{};
   bool is_success{};
   bool is_update_ = false;
-  static ros::Time last_update_time_;
   void unpack();
 };
 
-#endif  // SRC_RM_BRIDGE_INCLUDE_RT_RT_DBUS_H_
+#endif  // SRC_RM_BASE_INCLUDE_RT_RT_DBUS_H_

--- a/rm_dbus/src/dbus.cpp
+++ b/rm_dbus/src/dbus.cpp
@@ -168,6 +168,7 @@ void DBus::unpack()
   is_success = true;
 }
 
+static ros::Time last_update_time_;
 void DBus::getData(rm_msgs::DbusData& d_bus_data) const
 {
   if (is_success)
@@ -212,12 +213,12 @@ void DBus::getData(rm_msgs::DbusData& d_bus_data) const
         if (!d_bus_data.rc_is_open)
           d_bus_data.rc_is_open = !d_bus_data.rc_is_open;
       }
-      else
-      {
-        if (d_bus_data.rc_is_open)
-          d_bus_data.rc_is_open = !d_bus_data.rc_is_open;
-      }
       last_update_time_ = ros::Time::now();
+    }
+    else
+    {
+      if (d_bus_data.rc_is_open)
+        d_bus_data.rc_is_open = !d_bus_data.rc_is_open;
     }
   }
 }

--- a/rm_dbus/src/dbus.cpp
+++ b/rm_dbus/src/dbus.cpp
@@ -205,6 +205,19 @@ void DBus::getData(rm_msgs::DbusData& d_bus_data) const
     d_bus_data.key_v = (d_bus_data_.key >> 8) & 0x40 ? true : false;
     d_bus_data.key_b = (d_bus_data_.key >> 8) & 0x80 ? true : false;
     if (is_update_)
+    {
       d_bus_data.stamp = ros::Time::now();
+      if (ros::Time::now() - last_update_time_ < ros::Duration(1.0))
+      {
+        if (!d_bus_data.rc_is_open)
+          d_bus_data.rc_is_open = !d_bus_data.rc_is_open;
+      }
+      else
+      {
+        if (d_bus_data.rc_is_open)
+          d_bus_data.rc_is_open = !d_bus_data.rc_is_open;
+      }
+      last_update_time_ = ros::Time::now();
+    }
   }
 }

--- a/rm_msgs/msg/DbusData.msg
+++ b/rm_msgs/msg/DbusData.msg
@@ -33,5 +33,7 @@ bool key_x
 bool key_c
 bool key_v
 bool key_b
+#remote control
+bool rc_is_open
 
 time stamp


### PR DESCRIPTION
在DbusData.msg里加了rc_is_open值，用于判断遥控是否打开，并更新dbus相应逻辑。