### PR TITLE
Adjust power control method

### DIFF
--- a/rm_common/include/rm_common/decision/power_limit.h
+++ b/rm_common/include/rm_common/decision/power_limit.h
@@ -56,9 +56,9 @@ public:
       ROS_ERROR("Safety power no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("capacitor_threshold", capacitor_threshold_))
       ROS_ERROR("Capacitor threshold no defined (namespace: %s)", nh.getNamespace().c_str());
-    if (!nh.getParam("disable_cap_gyro_threshold",disable_cap_gyro_threshold_))
+    if (!nh.getParam("disable_cap_gyro_threshold", disable_cap_gyro_threshold_))
       ROS_ERROR("Disable cap gyro threshold no defined (namespace: %s)", nh.getNamespace().c_str());
-    if (!nh.getParam("enable_cap_gyro_threshold",enable_cap_gyro_threshold_))
+    if (!nh.getParam("enable_cap_gyro_threshold", enable_cap_gyro_threshold_))
       ROS_ERROR("Enable cap gyro threshold no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("charge_power", charge_power_))
       ROS_ERROR("Charge power no defined (namespace: %s)", nh.getNamespace().c_str());
@@ -66,12 +66,18 @@ public:
       ROS_ERROR("Extra power no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("burst_power", burst_power_))
       ROS_ERROR("Burst power no defined (namespace: %s)", nh.getNamespace().c_str());
+    if (!nh.getParam("standard_power", standard_power_))
+      ROS_ERROR("Standard power no defined (namespace: %s)", nh.getNamespace().c_str());
+    if (!nh.getParam("max_power_limit", max_power_limit_))
+      ROS_ERROR("max power limit no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("power_gain", power_gain_))
       ROS_ERROR("power gain no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("buffer_threshold", buffer_threshold_))
       ROS_ERROR("buffer threshold no defined (namespace: %s)", nh.getNamespace().c_str());
     if (!nh.getParam("is_new_capacitor", is_new_capacitor_))
       ROS_ERROR("is_new_capacitor no defined (namespace: %s)", nh.getNamespace().c_str());
+    if (!nh.getParam("total_burst_time", total_burst_time_))
+      ROS_ERROR("total burst time no defined (namespace: %s)", nh.getNamespace().c_str());
   }
   typedef enum
   {
@@ -107,6 +113,7 @@ public:
   void setChassisPowerBuffer(const rm_msgs::PowerHeatData data)
   {
     chassis_power_buffer_ = data.chassis_power_buffer;
+    power_buffer_threshold_ = chassis_power_buffer_ * 0.8;
   }
   void setCapacityData(const rm_msgs::PowerManagementSampleAndStatusData data)
   {
@@ -118,18 +125,25 @@ public:
   {
     referee_is_online_ = status;
   }
-
+  void setStartBurstTime(const ros::Time start_burst_time)
+  {
+    start_burst_time_ = start_burst_time;
+  }
+  ros::Time getStartBurstTime() const
+  {
+    return start_burst_time_;
+  }
   uint8_t getState()
   {
     return expect_state_;
   }
   void setGyroPower(rm_msgs::ChassisCmd& chassis_cmd)
   {
-    if (!allow_gyro_cap_ && cap_energy_>=enable_cap_gyro_threshold_)
+    if (!allow_gyro_cap_ && cap_energy_ >= enable_cap_gyro_threshold_)
       allow_gyro_cap_ = true;
-    if (allow_gyro_cap_ && cap_energy_<=disable_cap_gyro_threshold_)
+    if (allow_gyro_cap_ && cap_energy_ <= disable_cap_gyro_threshold_)
       allow_gyro_cap_ = false;
-    if ( allow_gyro_cap_ && chassis_power_limit_ < 80)
+    if (allow_gyro_cap_ && chassis_power_limit_ < 80)
       chassis_cmd.power_limit = chassis_power_limit_ + extra_power_;
     else
       expect_state_ = NORMAL;
@@ -184,6 +198,8 @@ private:
     double plus_power = buffer_energy_error * power_gain_;
     chassis_cmd.power_limit = chassis_power_limit_ + plus_power;
     // TODO:Add protection when buffer<5
+    if (chassis_cmd.power_limit > max_power_limit_)
+      chassis_cmd.power_limit = max_power_limit_;
   }
   void zero(rm_msgs::ChassisCmd& chassis_cmd)
   {
@@ -191,12 +207,14 @@ private:
   }
   void burst(rm_msgs::ChassisCmd& chassis_cmd, bool is_gyro)
   {
-    if (cap_state_ != ALLOFF && cap_energy_ > capacitor_threshold_)
+    if (cap_state_ != ALLOFF && cap_energy_ > capacitor_threshold_ && chassis_power_buffer_ > power_buffer_threshold_)
     {
       if (is_gyro)
         setGyroPower(chassis_cmd);
-      else
+      else if (ros::Time::now() - start_burst_time_ < ros::Duration(total_burst_time_))
         chassis_cmd.power_limit = burst_power_;
+      else
+        chassis_cmd.power_limit = standard_power_;
     }
     else
       expect_state_ = NORMAL;
@@ -204,17 +222,22 @@ private:
 
   int chassis_power_buffer_;
   int robot_id_, chassis_power_limit_;
+  int max_power_limit_{ 70 };
   float cap_energy_;
   double safety_power_{};
   double capacitor_threshold_{};
-  double enable_cap_gyro_threshold_{},disable_cap_gyro_threshold_{};
-  double charge_power_{}, extra_power_{}, burst_power_{};
+  double power_buffer_threshold_{ 50.0 };
+  double enable_cap_gyro_threshold_{}, disable_cap_gyro_threshold_{};
+  double charge_power_{}, extra_power_{}, burst_power_{}, standard_power_{};
   double buffer_threshold_{};
   double power_gain_{};
   bool is_new_capacitor_{ false };
   uint8_t expect_state_{}, cap_state_{};
   bool capacitor_is_on_{ true };
   bool allow_gyro_cap_{ false };
+
+  ros::Time start_burst_time_{};
+  int total_burst_time_{};
 
   bool referee_is_online_{ false };
   bool capacity_is_online_{ false };

--- a/rm_msgs/msg/referee/ManualToReferee.msg
+++ b/rm_msgs/msg/referee/ManualToReferee.msg
@@ -1,4 +1,5 @@
 uint8 power_limit_state
+time start_burst_time
 
 #standard
 uint8 shoot_frequency


### PR DESCRIPTION
调整功率控制方式：
1. 新增使用超电小陀螺：当超电容量高于设定阈值，允许使用超电小陀螺
2. 调整busrt模式的功率使用：默认功率为standard_power(120w)，当操作手按下b键后，20s内功率为burst_power(220w)
若不需要调整burst模式的功率，则将standard_power和burst_power设为相同即可